### PR TITLE
Fix kernel 6.8 build compatibility; add TP-Link Archer TX35U Plus

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ This driver supports USB adapters based on the **RTL8852AU** and **RTL8832AU** c
 | `0e8d:0608` | MediaTek-branded RTL8852AU | RTL8852AU | Yes |
 | `2357:012e` | TP-Link Archer TX20U Nano | RTL8852AU | Yes |
 | `2357:012f` | TP-Link Archer TX20U Plus | RTL8852AU | Yes |
+| `3625:010f` | TP-Link Archer TX35U Plus | RTL8852AU | Yes |
 | `0b05:1a62` | ASUS USB-AX56 (No Cradle) | RTL8832AU | Yes |
 | `13b1:0465` | Linksys WUSB6400M v2 | RTL8852AU | Reported |
 | `0846:9060` | NETGEAR A8000 | RTL8852AU | Reported |

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -3436,7 +3436,11 @@ static void cfg80211_rtw_abort_scan(struct wiphy *wiphy,
 }
 #endif /* LINUX_VERSION_CODE >= 4.5.0 */
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 18, 0))
 static int cfg80211_rtw_set_wiphy_params(struct wiphy *wiphy, int radio_idx, u32 changed)
+#else
+static int cfg80211_rtw_set_wiphy_params(struct wiphy *wiphy, u32 changed)
+#endif
 {
 #if 0
 	struct iwm_priv *iwm = wiphy_to_iwm(wiphy);
@@ -4411,10 +4415,16 @@ static int cfg80211_rtw_disconnect(struct wiphy *wiphy, struct net_device *ndev,
 	return 0;
 }
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 18, 0))
 static int cfg80211_rtw_set_txpower(struct wiphy *wiphy,
 	struct wireless_dev *wdev,
 	int radio_idx,
 	enum nl80211_tx_power_setting type, int mbm)
+#else
+static int cfg80211_rtw_set_txpower(struct wiphy *wiphy,
+	struct wireless_dev *wdev,
+	enum nl80211_tx_power_setting type, int mbm)
+#endif
 {
 #if 0
 	struct iwm_priv *iwm = wiphy_to_iwm(wiphy);
@@ -4446,10 +4456,16 @@ static int cfg80211_rtw_set_txpower(struct wiphy *wiphy,
 	return 0;
 }
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 18, 0))
 static int cfg80211_rtw_get_txpower(struct wiphy *wiphy,
 	struct wireless_dev *wdev,
 	int radio_idx, unsigned int link_id,
 	int *dbm)
+#else
+static int cfg80211_rtw_get_txpower(struct wiphy *wiphy,
+	struct wireless_dev *wdev,
+	int *dbm)
+#endif
 {
 	RTW_INFO("%s\n", __func__);
 
@@ -6342,9 +6358,14 @@ static void rtw_get_chbwoff_from_cfg80211_chan_def(
 }
 #endif /* (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)) */
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 18, 0))
 static int cfg80211_rtw_set_monitor_channel(struct wiphy *wiphy,
 	struct net_device *dev,
 	struct cfg80211_chan_def *chandef)
+#else
+static int cfg80211_rtw_set_monitor_channel(struct wiphy *wiphy,
+	struct cfg80211_chan_def *chandef)
+#endif
 {
 	_adapter *padapter = wiphy_to_adapter(wiphy);
 	u8 target_channal, target_offset, target_width, ht_option;

--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -163,6 +163,7 @@ static struct usb_device_id rtw_usb_id_tbl[] = {
 
         /*=== TP-Link AX1800 ===*/
 	{USB_DEVICE_AND_INTERFACE_INFO(0x35bc, 0x0100, 0xff, 0xff, 0xff), .driver_info = RTL8852A},
+	{USB_DEVICE_AND_INTERFACE_INFO(0x3625, 0x010f, 0xff, 0xff, 0xff), .driver_info = RTL8852A}, /* TP-Link Archer TX35U Plus */
 	{USB_DEVICE_AND_INTERFACE_INFO(USB_VENDOR_ID_TPLINK, 0x013f, 0xff, 0xff, 0xff), .driver_info = RTL8852A},
 	{USB_DEVICE_AND_INTERFACE_INFO(USB_VENDOR_ID_TPLINK, 0x0140, 0xff, 0xff, 0xff), .driver_info = RTL8852A},
 	{USB_DEVICE_AND_INTERFACE_INFO(USB_VENDOR_ID_TPLINK, 0x0141, 0xff, 0xff, 0xff), .driver_info = RTL8852A},

--- a/phl/hal_g6/hal_ser.h
+++ b/phl/hal_g6/hal_ser.h
@@ -15,4 +15,7 @@
 #ifndef _HAL_SER_H_
 #define _HAL_SER_H_
 
+u32 rtw_hal_ser_get_error_status(void *hal, u32 *err);
+enum rtw_hal_status rtw_hal_ser_set_error_status(void *hal, u32 err);
+
 #endif /* _HAL_SER_H_ */


### PR DESCRIPTION
## Fix build on kernel 6.8

The cfg80211 MLO API introduced new parameters (`radio_idx`, `link_id`,
`struct net_device *`) in several callbacks in kernel 6.18. Without
version guards, the driver fails to build on kernel 6.8 (e.g. Ubuntu
24.04 LTS), which uses the pre-MLO signatures.

## Add USB ID for TP-Link Archer TX35U Plus

Adds USB ID `3625:010f` for the TP-Link Archer TX35U Plus. Confirmed
working with this driver on Linux 6.8.