### PR TITLE
docs: document verified kernel 7.0 build support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,21 @@ changes in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- **Documented kernel 7.0 support.** The compatibility badge and table now
+  advertise the 6.1 → 7.0 range. No driver source changed — the existing
+  6.17/6.18 `LINUX_VERSION_CODE` gates already carry the build across the
+  7.0 boundary.
+
 ### Verified
+
+- **Clean build against Linux 7.0.12+kali-amd64** (Kali `7.0.12-2kali1`,
+  2026-06-18, GCC 15.3.0): `make` exits 0 and `8852au.ko` links with BTF
+  (vermagic `7.0.12+kali-amd64 SMP preempt mod_unload`). Only the vendor
+  tree's usual `-Wmissing-prototypes` warnings, **zero errors, no new
+  patches required.** Compile-verified only — not hardware-tested on this
+  kernel (no adapter attached to the build host).
 
 - **Patch 0007 (`netdev_close` mutex + skip-on-remove) is now
   hardware-validated** on a TP-Link Archer TX20U Plus (`2357:013f`)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![CI](https://github.com/WimLee115/rtl8852au-build/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/WimLee115/rtl8852au-build/actions/workflows/ci.yml)
 [![License: GPL-2.0](https://img.shields.io/badge/license-GPL--2.0-blue.svg)](LICENSE)
-[![Kernel](https://img.shields.io/badge/kernel-6.1%20%E2%80%93%206.19%2B-informational.svg)](#compatibility)
+[![Kernel](https://img.shields.io/badge/kernel-6.1%20%E2%80%93%207.0%2B-informational.svg)](#compatibility)
 
 Out-of-tree Linux driver for USB WiFi adapters based on the Realtek
 **RTL8852AU** and **RTL8832AU** (WiFi 6, AX1800) chipsets. The upstream
@@ -231,10 +231,11 @@ sudo ./tests/run_tests.sh --all          # everything, including destructive
 | Distribution               | Kernel             | Arch    | Verified by         |
 |----------------------------|--------------------|---------|---------------------|
 | Kali Linux Rolling 2026.1  | 6.19.14+kali-amd64 | x86_64  | Maintainer hardware |
+| Kali Linux Rolling         | 7.0.12+kali-amd64  | x86_64  | Maintainer build    |
 | Ubuntu 22.04 LTS           | distro default     | x86_64  | CI build matrix     |
 | Ubuntu 24.04 LTS           | distro default     | x86_64  | CI build matrix     |
 
-Other kernels in the 6.1 LTS → 6.19+ range are expected to compile
+Other kernels in the 6.1 LTS → 7.0+ range are expected to compile
 because every patch is gated on the relevant `LINUX_VERSION_CODE`, but
 they are not verified by the maintainer.
 

--- a/README.nl.md
+++ b/README.nl.md
@@ -4,7 +4,7 @@
 
 [![CI](https://github.com/WimLee115/rtl8852au-build/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/WimLee115/rtl8852au-build/actions/workflows/ci.yml)
 [![Licentie: GPL-2.0](https://img.shields.io/badge/licentie-GPL--2.0-blue.svg)](LICENSE)
-[![Kernel](https://img.shields.io/badge/kernel-6.1%20%E2%80%93%206.19%2B-informational.svg)](#compatibiliteit)
+[![Kernel](https://img.shields.io/badge/kernel-6.1%20%E2%80%93%207.0%2B-informational.svg)](#compatibiliteit)
 
 Out-of-tree Linux-driver voor USB-WiFi-adapters gebaseerd op de Realtek
 **RTL8852AU**- en **RTL8832AU**-chipsets (WiFi 6, AX1800). De upstream
@@ -241,10 +241,11 @@ sudo ./tests/run_tests.sh --all          # alles, inclusief destructief
 | Distributie                  | Kernel             | Architectuur | Geverifieerd door     |
 |------------------------------|--------------------|--------------|-----------------------|
 | Kali Linux Rolling 2026.1    | 6.19.14+kali-amd64 | x86_64       | Maintainer-hardware   |
+| Kali Linux Rolling           | 7.0.12+kali-amd64  | x86_64       | Maintainer-build      |
 | Ubuntu 22.04 LTS             | distributie-default | x86_64      | CI-bouw-matrix        |
 | Ubuntu 24.04 LTS             | distributie-default | x86_64      | CI-bouw-matrix        |
 
-Andere kernels in het bereik 6.1 LTS → 6.19+ worden verwacht te
+Andere kernels in het bereik 6.1 LTS → 7.0+ worden verwacht te
 compileren omdat elke patch gebonden is aan een
 `LINUX_VERSION_CODE`-conditie, maar zijn niet door de maintainer
 geverifieerd.


### PR DESCRIPTION
## What

Documents that the driver builds cleanly on **Linux kernel 7.0** and extends the compatibility badge/table from `6.19+` to `7.0+`.

**No driver source changed** — the existing 6.17/6.18 `LINUX_VERSION_CODE` gates already carry the build across the 7.0 boundary.

## Verification

Built against **Linux 7.0.12+kali-amd64** (Kali `7.0.12-2kali1`, 2026-06-18) with GCC 15.3.0:

- `make` exits 0; `8852au.ko` links with BTF
- vermagic `7.0.12+kali-amd64 SMP preempt mod_unload`
- zero errors; only the vendor tree's usual `-Wmissing-prototypes` warnings

Compile-verified only — not hardware-tested on this kernel (no adapter attached to the build host).

## Changes

- `README.md` / `README.nl.md`: kernel badge `6.1 – 7.0+`, new `7.0.12+kali` compatibility row
- `CHANGELOG.md`: Unreleased entry (Changed + Verified)

## Follow-up (separate change)

CI currently builds only against Ubuntu 22.04/24.04 distro kernels (~6.8–6.11), so it does not actually exercise 6.19/7.0. Extending the CI matrix to a current mainline kernel would close that blind spot.