### PR TITLE
docs: credit @74Thirsty + add D-Link DWA-1850 (2001:332c) to device table

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ table below is generated from `os_dep/linux/usb_intf.c`.
 | `0411:0312`  | Buffalo WI-U3-1200AX2(/N)      | RTL8852AU  | Recognised |
 | `2001:0141`  | D-Link DWA-X1850               | RTL8852AU  | Recognised |
 | `2001:3321`  | D-Link DWA-X1850 (variant)     | RTL8852AU  | Recognised |
+| `2001:332c`  | D-Link DWA-1850                | RTL8832AU  | Recognised |
 | `35bc:0100`  | TP-Link AX1800 (generic)       | RTL8852AU  | Recognised |
 | `2357:013f`  | TP-Link Archer TX20U Plus      | RTL8852AU  | **Tested** |
 | `2357:0140`  | TP-Link AX1800 (variant)       | RTL8852AU  | Recognised |
@@ -393,7 +394,9 @@ driver-source patches. In short:
 - **[morrownr](https://github.com/morrownr)** — USB WiFi adapter
   documentation, USB-ID references, maintenance patterns.
 - **[Joan Sala (`jsiwrk`)](https://github.com/jsiwrk)** — TP-Link
-  Archer TX35U Plus USB ID (PR #3).
+  Archer TX35U Plus USB ID and the kernel 6.8 build fix (PR #3).
+- **[74Thirsty (`gadgetsaavy`)](https://github.com/74Thirsty)** — D-Link
+  DWA-1850 USB ID `2001:332c` and Parrot OS 6/7 testing (PR #14).
 - **[WimLee115](https://github.com/WimLee115)** — fork maintenance,
   kernel-compatibility patches, test suite, dashboard.
 

--- a/README.nl.md
+++ b/README.nl.md
@@ -156,6 +156,7 @@ USB-adapters gebaseerd op de **RTL8852AU**- of
 | `0411:0312`  | Buffalo WI-U3-1200AX2(/N)      | RTL8852AU  | Herkend    |
 | `2001:0141`  | D-Link DWA-X1850               | RTL8852AU  | Herkend    |
 | `2001:3321`  | D-Link DWA-X1850 (variant)     | RTL8852AU  | Herkend    |
+| `2001:332c`  | D-Link DWA-1850                | RTL8832AU  | Herkend    |
 | `35bc:0100`  | TP-Link AX1800 (generiek)      | RTL8852AU  | Herkend    |
 | `2357:013f`  | TP-Link Archer TX20U Plus      | RTL8852AU  | **Getest** |
 | `2357:0140`  | TP-Link AX1800 (variant)       | RTL8852AU  | Herkend    |
@@ -426,7 +427,9 @@ Zoals bij elke out-of-tree-kernelmodule wordt de software
 - **[morrownr](https://github.com/morrownr)** — USB-WiFi-adapter
   documentatie, USB-ID-referenties, onderhoudspatronen.
 - **[Joan Sala (`jsiwrk`)](https://github.com/jsiwrk)** — TP-Link
-  Archer TX35U Plus USB-ID (PR #3).
+  Archer TX35U Plus USB-ID en de kernel 6.8-buildfix (PR #3).
+- **[74Thirsty (`gadgetsaavy`)](https://github.com/74Thirsty)** — D-Link
+  DWA-1850 USB-ID `2001:332c` en testen op Parrot OS 6/7 (PR #14).
 - **[WimLee115](https://github.com/WimLee115)** — fork-onderhoud,
   kernel-compatibiliteit-patches, test suite, dashboard.
 

--- a/RELEASE_NOTES_v1.16.0.md
+++ b/RELEASE_NOTES_v1.16.0.md
@@ -40,7 +40,7 @@ Full instructions, troubleshooting, and the dashboard/test-suite guides are in t
 
 ## Supported devices
 
-RTL8852AU / RTL8832AU USB adapters — 14 USB IDs across TP-Link, ASUS, D-Link, Buffalo, Elecom and the Realtek reference boards. Full table: [supported devices](https://github.com/WimLee115/rtl8852au-build/blob/main/README.md#supported-devices). Have one working that's only *Recognised*? [Send an `lsusb -v` report](https://github.com/WimLee115/rtl8852au-build/issues/new?template=hardware_support.yml) and it moves to *Tested*.
+RTL8852AU / RTL8832AU USB adapters — 15 USB IDs across TP-Link, ASUS, D-Link, Buffalo, Elecom and the Realtek reference boards. Full table: [supported devices](https://github.com/WimLee115/rtl8852au-build/blob/main/README.md#supported-devices). Have one working that's only *Recognised*? [Send an `lsusb -v` report](https://github.com/WimLee115/rtl8852au-build/issues/new?template=hardware_support.yml) and it moves to *Tested*.
 
 ## Known limitations
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -374,7 +374,7 @@
     <div class="why">
       <div class="cell"><div class="n">12</div><div class="k">version-gated kernel 6.17+ compatibility patches</div></div>
       <div class="cell"><div class="n">4</div><div class="k">monitor-mode RX-path crash fixes (UAF, race, OOB, NULL-deref)</div></div>
-      <div class="cell"><div class="n">14</div><div class="k">supported USB IDs across TP-Link, ASUS, D-Link, Buffalo, Elecom</div></div>
+      <div class="cell"><div class="n">15</div><div class="k">supported USB IDs across TP-Link, ASUS, D-Link, Buffalo, Elecom</div></div>
       <div class="cell"><div class="n">4×</div><div class="k">CI kernels: two distro + mainline stable &amp; longterm</div></div>
     </div>
   </div>
@@ -444,6 +444,7 @@
           <tr><td class="id">0411:0312</td><td>Buffalo WI-U3-1200AX2(/N)</td><td>RTL8852AU</td><td><span class="pill reco">Recognised</span></td></tr>
           <tr><td class="id">2001:0141</td><td>D-Link DWA-X1850</td><td>RTL8852AU</td><td><span class="pill reco">Recognised</span></td></tr>
           <tr><td class="id">2001:3321</td><td>D-Link DWA-X1850 (variant)</td><td>RTL8852AU</td><td><span class="pill reco">Recognised</span></td></tr>
+          <tr><td class="id">2001:332c</td><td>D-Link DWA-1850</td><td>RTL8832AU</td><td><span class="pill reco">Recognised</span></td></tr>
           <tr><td class="id">35bc:0100</td><td>TP-Link AX1800 (generic)</td><td>RTL8852AU</td><td><span class="pill reco">Recognised</span></td></tr>
           <tr><td class="id">2357:0140</td><td>TP-Link AX1800 (variant)</td><td>RTL8852AU</td><td><span class="pill reco">Recognised</span></td></tr>
           <tr><td class="id">2357:0141</td><td>TP-Link AX1800 (variant)</td><td>RTL8852AU</td><td><span class="pill reco">Recognised</span></td></tr>


### PR DESCRIPTION
Adds @74Thirsty / gadgetsaavy to Credits for the D-Link DWA-1850 USB ID `2001:332c` and Parrot OS 6/7 testing (PR #14), and adds the matching `2001:332c` row that ships in the driver but was missing from the device tables (README, README.nl, landing page). USB-ID count corrected 14 -> 15. Also notes jsiwrk's kernel 6.8 build fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LPw821xjyPfYvUVAfTcTPF