### PR TITLE
docs: complete credits in release notes + landing page footer

### DIFF
--- a/RELEASE_NOTES_v1.16.0.md
+++ b/RELEASE_NOTES_v1.16.0.md
@@ -52,7 +52,7 @@ This is the first release under the fork's **own SemVer line**. Earlier fork tag
 
 ## Credits
 
-Realtek (original vendor driver), [lwfinger](https://github.com/lwfinger) and [morrownr](https://github.com/morrownr) (community packaging & USB-ID references), and [jsiwrk](https://github.com/jsiwrk) (TP-Link Archer TX35U Plus USB ID, PR #3).
+Realtek (original vendor driver), [lwfinger](https://github.com/lwfinger) and [morrownr](https://github.com/morrownr) (community packaging & USB-ID references), [jsiwrk](https://github.com/jsiwrk) (TP-Link Archer TX35U Plus USB ID and the kernel 6.8 build fix, PR #3), and [74Thirsty](https://github.com/74Thirsty) (D-Link DWA-1850 USB ID `2001:332c` and Parrot OS 6/7 testing, PR #14).
 
 ---
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -583,6 +583,9 @@
       </div>
     </div>
     <p class="disclaimer">
+      <strong>Credits.</strong> Realtek (vendor driver) · <a href="https://github.com/lwfinger">lwfinger</a> &amp; <a href="https://github.com/morrownr">morrownr</a> (community packaging, USB-ID references) · <a href="https://github.com/jsiwrk">jsiwrk</a> (Archer TX35U Plus ID + kernel 6.8 fix) · <a href="https://github.com/74Thirsty">74Thirsty</a> (D-Link DWA-1850 <code>2001:332c</code>) · <a href="https://github.com/WimLee115">WimLee115</a> (fork maintenance).
+    </p>
+    <p class="disclaimer" style="border-top:none;padding-top:6px">
       <strong>Disclaimer.</strong> Independent community fork — not affiliated with, endorsed by, or sponsored by Realtek Semiconductor Corp., TP-Link, ASUSTeK, D-Link, Buffalo, Elecom, or any other hardware vendor named here; product names and USB IDs are for identification only. The firmware blob is © Realtek and redistributed unchanged from the <code>v1.15.0.1-2</code> vendor source, checksum-verified in CI. Released under the <a href="https://github.com/WimLee115/rtl8852au-build/blob/main/LICENSE">GNU GPL-2.0</a>; provided “AS IS” without warranty of any kind.
     </p>
   </div>


### PR DESCRIPTION
Consistency follow-up to the contributor audit: adds @74Thirsty and jsiwrk's kernel 6.8 fix to the v1.16.0 release-notes Credits, and adds a footer Credits line to the landing page naming all contributors/acknowledgements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LPw821xjyPfYvUVAfTcTPF