### PR TITLE
docs: add CONTRIBUTORS.md with the full contributor roster

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,45 @@
+# Contributors
+
+Everyone who has helped make **rtl8852au-build** what it is. This mirrors
+the credits in the [README](README.md) and [CHANGELOG](CHANGELOG.md); the
+GitHub [contributors graph](https://github.com/WimLee115/rtl8852au-build/graphs/contributors)
+is generated automatically from commit history.
+
+## Maintainer
+
+- **[WimLee115](https://github.com/WimLee115)** — fork maintenance, the
+  twelve kernel 6.1 → 7.0+ compatibility patches, the monitor-mode crash
+  fixes, DKMS packaging, the Flask dashboard, the test suite, and CI.
+
+## Contributors
+
+- **[Joan Sala — `jsiwrk`](https://github.com/jsiwrk)** — TP-Link Archer
+  TX35U Plus USB ID (`3625:010f`) and the kernel 6.8 build fix
+  ([PR #3](https://github.com/WimLee115/rtl8852au-build/pull/3)).
+- **[74Thirsty — `gadgetsaavy`](https://github.com/74Thirsty)** — D-Link
+  DWA-1850 USB ID (`2001:332c`) and Parrot OS 6/7 testing
+  ([PR #14](https://github.com/WimLee115/rtl8852au-build/pull/14)).
+
+## Acknowledgements
+
+Not commit contributors to this repository, but this fork stands on their
+work:
+
+- **Realtek Semiconductor Corp.** — the original vendor driver
+  (`v1.15.0.1-2`) this fork is based on.
+- **[lwfinger (Larry Finger)](https://github.com/lwfinger)** — long-running
+  community Linux packaging of the Realtek WiFi drivers.
+- **[morrownr](https://github.com/morrownr)** — USB WiFi adapter
+  documentation, USB-ID references, and maintenance patterns.
+
+## Adding yourself
+
+New contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md).
+Open a pull request; once it is merged you appear in the GitHub
+contributors graph automatically, and substantial changes are recorded
+here and in the README credits.
+
+---
+
+*Bots (e.g. Dependabot) that appear in the commit history are intentionally
+excluded from this list.*


### PR DESCRIPTION
Adds an explicit, maintained CONTRIBUTORS.md (GitHub's contributors graph is auto-generated and can't be curated). Lists @74Thirsty, jsiwrk, the maintainer, and the upstream acknowledgements; bots excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LPw821xjyPfYvUVAfTcTPF