### PR TITLE
docs: link CONTRIBUTORS.md from the README credits

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,9 @@ driver-source patches. In short:
 - **[WimLee115](https://github.com/WimLee115)** — fork maintenance,
   kernel-compatibility patches, test suite, dashboard.
 
+See [`CONTRIBUTORS.md`](CONTRIBUTORS.md) for the full list of contributors
+and acknowledgements.
+
 ## Disclaimer
 
 This is an **independent community fork**. It is not affiliated with,

--- a/README.nl.md
+++ b/README.nl.md
@@ -433,6 +433,9 @@ Zoals bij elke out-of-tree-kernelmodule wordt de software
 - **[WimLee115](https://github.com/WimLee115)** — fork-onderhoud,
   kernel-compatibiliteit-patches, test suite, dashboard.
 
+Zie [`CONTRIBUTORS.md`](CONTRIBUTORS.md) voor de volledige lijst met
+bijdragers en acknowledgements.
+
 ## Licentie
 
 GNU General Public License v2.0 — zie [`LICENSE`](LICENSE). De


### PR DESCRIPTION
Adds a pointer to CONTRIBUTORS.md at the end of the Credits section in both README.md and README.nl.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LPw821xjyPfYvUVAfTcTPF