### PR TITLE
docs: add Dutch CONTRIBUTORS.nl.md + language switcher

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,5 +1,7 @@
 # Contributors
 
+**English** | [Nederlands](CONTRIBUTORS.nl.md)
+
 Everyone who has helped make **rtl8852au-build** what it is. This mirrors
 the credits in the [README](README.md) and [CHANGELOG](CHANGELOG.md); the
 GitHub [contributors graph](https://github.com/WimLee115/rtl8852au-build/graphs/contributors)

--- a/CONTRIBUTORS.nl.md
+++ b/CONTRIBUTORS.nl.md
@@ -1,0 +1,47 @@
+# Bijdragers
+
+[English](CONTRIBUTORS.md) | **Nederlands**
+
+Iedereen die heeft geholpen **rtl8852au-build** te maken tot wat het is.
+Dit weerspiegelt de credits in de [README](README.nl.md) en de
+[CHANGELOG](CHANGELOG.md); de GitHub-[contributors-grafiek](https://github.com/WimLee115/rtl8852au-build/graphs/contributors)
+wordt automatisch gegenereerd uit de commit-historie.
+
+## Maintainer
+
+- **[WimLee115](https://github.com/WimLee115)** — fork-onderhoud, de twaalf
+  kernel 6.1 → 7.0+ compatibiliteitspatches, de monitor-mode-crashfixes,
+  DKMS-packaging, het Flask-dashboard, de test suite en CI.
+
+## Bijdragers
+
+- **[Joan Sala — `jsiwrk`](https://github.com/jsiwrk)** — TP-Link Archer
+  TX35U Plus USB-ID (`3625:010f`) en de kernel 6.8-buildfix
+  ([PR #3](https://github.com/WimLee115/rtl8852au-build/pull/3)).
+- **[74Thirsty — `gadgetsaavy`](https://github.com/74Thirsty)** — D-Link
+  DWA-1850 USB-ID (`2001:332c`) en testen op Parrot OS 6/7
+  ([PR #14](https://github.com/WimLee115/rtl8852au-build/pull/14)).
+
+## Acknowledgements
+
+Geen commit-bijdragers aan deze repo, maar deze fork bouwt voort op hun
+werk:
+
+- **Realtek Semiconductor Corp.** — de originele vendor-driver
+  (`v1.15.0.1-2`) waarop deze fork is gebaseerd.
+- **[lwfinger (Larry Finger)](https://github.com/lwfinger)** — langjarige
+  community-Linux-packaging van de Realtek-WiFi-drivers.
+- **[morrownr](https://github.com/morrownr)** — USB-WiFi-adapter-documentatie,
+  USB-ID-referenties en onderhoudspatronen.
+
+## Jezelf toevoegen
+
+Nieuwe bijdragen zijn welkom — zie [CONTRIBUTING.nl.md](CONTRIBUTING.nl.md).
+Open een pull request; zodra die gemerged is, verschijn je automatisch in
+de GitHub-contributors-grafiek, en substantiële wijzigingen worden hier en
+in de README-credits vastgelegd.
+
+---
+
+*Bots (bijv. Dependabot) die in de commit-historie voorkomen, worden bewust
+uit deze lijst weggelaten.*


### PR DESCRIPTION
Adds the NL variant of the contributor roster and the English/Nederlands switcher header on both files, matching the repo's bilingual convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LPw821xjyPfYvUVAfTcTPF