### PR TITLE
docs: point README.nl.md credits to CONTRIBUTORS.nl.md

### DIFF
--- a/README.nl.md
+++ b/README.nl.md
@@ -433,7 +433,7 @@ Zoals bij elke out-of-tree-kernelmodule wordt de software
 - **[WimLee115](https://github.com/WimLee115)** — fork-onderhoud,
   kernel-compatibiliteit-patches, test suite, dashboard.
 
-Zie [`CONTRIBUTORS.md`](CONTRIBUTORS.md) voor de volledige lijst met
+Zie [`CONTRIBUTORS.nl.md`](CONTRIBUTORS.nl.md) voor de volledige lijst met
 bijdragers en acknowledgements.
 
 ## Licentie


### PR DESCRIPTION
The Dutch README credits now link directly to the Dutch contributor roster (CONTRIBUTORS.nl.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LPw821xjyPfYvUVAfTcTPF