### PR TITLE
docs: reference CONTRIBUTORS from the contributing guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,10 @@ In the PR description, include:
    succeeds on at least one current kernel (6.12 LTS or newer).
 4. Open a PR. CI will build on Ubuntu 22.04 + 24.04 and run lint.
 
+Once your PR is merged you appear in the GitHub contributors graph;
+substantial contributions are also listed in
+[`CONTRIBUTORS.md`](CONTRIBUTORS.md).
+
 ### Style
 
 - Driver source: match Realtek's vendor style (tabs, K&R braces, no

--- a/CONTRIBUTING.nl.md
+++ b/CONTRIBUTING.nl.md
@@ -64,6 +64,10 @@ Voeg in de PR-beschrijving toe:
    `make` op minstens één recente kernel slaagt (6.12 LTS of nieuwer).
 4. Open een PR. CI bouwt op Ubuntu 22.04 + 24.04 en draait lint.
 
+Zodra je PR gemerged is, verschijn je automatisch in de
+GitHub-contributors-grafiek; substantiële bijdragen worden bovendien
+vermeld in [`CONTRIBUTORS.nl.md`](CONTRIBUTORS.nl.md).
+
 ### Stijl
 
 - Driver-source: volg Realtek's vendor-stijl (tabs, K&R-braces, geen


### PR DESCRIPTION
CONTRIBUTING.nl.md -> CONTRIBUTORS.nl.md and CONTRIBUTING.md -> CONTRIBUTORS.md, so contributors know where merged work is credited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LPw821xjyPfYvUVAfTcTPF