### PR TITLE
docs: add Contributors (NL) to the landing-page footer links

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -581,6 +581,7 @@
           <li><a href="https://github.com/WimLee115/rtl8852au-build/issues/new?template=hardware_support.yml">Hardware request</a></li>
           <li><a href="https://github.com/WimLee115/rtl8852au-build/blob/main/CONTRIBUTING.md">Contributing</a></li>
           <li><a href="https://github.com/WimLee115/rtl8852au-build/blob/main/CONTRIBUTORS.md">Contributors</a></li>
+          <li><a href="https://github.com/WimLee115/rtl8852au-build/blob/main/CONTRIBUTORS.nl.md">Contributors (NL)</a></li>
           <li><a href="https://github.com/WimLee115/rtl8852au-build/blob/main/SECURITY.md">Security policy</a></li>
         </ul>
       </div>


### PR DESCRIPTION
Adds a Contributors (NL) entry (CONTRIBUTORS.nl.md) to the Project column of the footer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LPw821xjyPfYvUVAfTcTPF