### PR TITLE
docs: link CONTRIBUTORS.nl.md from the README.md credits

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,8 +400,8 @@ driver-source patches. In short:
 - **[WimLee115](https://github.com/WimLee115)** — fork maintenance,
   kernel-compatibility patches, test suite, dashboard.
 
-See [`CONTRIBUTORS.md`](CONTRIBUTORS.md) for the full list of contributors
-and acknowledgements.
+See [`CONTRIBUTORS.md`](CONTRIBUTORS.md) ([Nederlands](CONTRIBUTORS.nl.md))
+for the full list of contributors and acknowledgements.
 
 ## Disclaimer
 


### PR DESCRIPTION
The English README credits now also point to CONTRIBUTORS.nl.md alongside CONTRIBUTORS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LPw821xjyPfYvUVAfTcTPF