### PR TITLE
docs: align why-strip patch tile to "kernel 6.1 → 7.0+"

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -374,7 +374,7 @@
       <p>Every claim below maps to a commit, a patch file in <code>patches/</code>, or a CI job — not marketing.</p>
     </div>
     <div class="why">
-      <div class="cell"><div class="n">12</div><div class="k">version-gated kernel 6.17+ compatibility patches</div></div>
+      <div class="cell"><div class="n">12</div><div class="k">version-gated compatibility patches for kernel 6.1&nbsp;→&nbsp;7.0+</div></div>
       <div class="cell"><div class="n">4</div><div class="k">monitor-mode RX-path crash fixes (UAF, race, OOB, NULL-deref)</div></div>
       <div class="cell"><div class="n">15</div><div class="k">supported USB IDs across TP-Link, ASUS, D-Link, Buffalo, Elecom</div></div>
       <div class="cell"><div class="n">4×</div><div class="k">CI kernels: two distro + mainline stable &amp; longterm</div></div>


### PR DESCRIPTION
Reframes the 12-patches tile to match the hero, badges, and About text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LPw821xjyPfYvUVAfTcTPF