### PR TITLE
docs: update release-process docs to SemVer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,6 @@ substantial contributions are also listed in
 
 ## Release process
 
-The maintainer tags releases as `v<vendor-version>+<fork-count>` (for
-example `v1.15.0.1+7`). The CI builds artefacts; once green, a GitHub
+The maintainer tags releases as SemVer `vMAJOR.MINOR.PATCH` (for
+example `v1.16.0`). The CI builds artefacts; once green, a GitHub
 release is cut with the changelog entry copy-pasted from `CHANGELOG.md`.

--- a/CONTRIBUTING.nl.md
+++ b/CONTRIBUTING.nl.md
@@ -78,7 +78,7 @@ vermeld in [`CONTRIBUTORS.nl.md`](CONTRIBUTORS.nl.md).
 
 ## Release-proces
 
-De maintainer tagt releases als `v<vendor-versie>+<fork-count>`
-(bijvoorbeeld `v1.15.0.1+7`). CI bouwt artefacten; zodra die groen
+De maintainer tagt releases volgens SemVer `vMAJOR.MINOR.PATCH`
+(bijvoorbeeld `v1.16.0`). CI bouwt artefacten; zodra die groen
 zijn wordt een GitHub-release uitgebracht met de CHANGELOG-entry
 gekopieerd uit `CHANGELOG.md`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -102,7 +102,7 @@ sequenceDiagram
     CI-->>Dev: all checks green
     Dev->>Patches: git format-patch -1 -> patches/00NN-*.patch
     Patches->>Source: stays in sync with tree
-    Dev->>Source: tag v1.15.0.1+N (annotated)
+    Dev->>Source: tag vX.Y.Z SemVer (annotated)
 ```
 
 ## Lifecycle of a dashboard status update

--- a/docs/architecture.nl.md
+++ b/docs/architecture.nl.md
@@ -102,7 +102,7 @@ sequenceDiagram
     CI-->>Dev: alle checks groen
     Dev->>Patches: git format-patch -1 -> patches/00NN-*.patch
     Patches->>Source: blijft in sync met tree
-    Dev->>Source: tag v1.15.0.1+N (geannoteerd)
+    Dev->>Source: tag vX.Y.Z SemVer (geannoteerd)
 ```
 
 ## Levensloop van een status-update in het dashboard


### PR DESCRIPTION
Updates CONTRIBUTING(.nl).md release-process and the architecture diagrams to SemVer (v1.16.0), replacing the old vendor+fork-count scheme. Historical 1.15.0.1+N refs in CHANGELOG/RELEASE_NOTES kept as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LPw821xjyPfYvUVAfTcTPF