### PR TITLE
fix: make DKMS status checks race-free and version-exact

### DIFF
--- a/dkms-install.sh
+++ b/dkms-install.sh
@@ -55,8 +55,16 @@ fi
 
 echo "==> Installing ${PKG_NAME} ${PKG_VER} via DKMS"
 
-# Remove any stale registration for this name+version (idempotent re-run)
-if dkms status | grep -qE "^${PKG_NAME}/${PKG_VER}"; then
+# Remove any stale registration for this name+version (idempotent re-run).
+#
+# Ask DKMS to filter by name+version directly instead of piping `dkms status`
+# into `grep -q`. That pipeline had two bugs: (1) `grep -q` closes the pipe on
+# its first match, sending SIGPIPE to `dkms status`, which under `set -o
+# pipefail` makes the whole condition fail — so the stale entry silently
+# survived and the later `dkms add` collided with "module/version already in
+# the tree"; (2) PACKAGE_VERSION was used unescaped in a regex, so the dots in
+# 1.15.0.1 matched any character. Filtering server-side sidesteps both.
+if [[ -n "$(dkms status -m "${PKG_NAME}" -v "${PKG_VER}" 2>/dev/null || true)" ]]; then
     echo "==> Removing existing DKMS entry ${PKG_NAME}/${PKG_VER}"
     dkms remove -m "${PKG_NAME}" -v "${PKG_VER}" --all || true
 fi

--- a/dkms-remove.sh
+++ b/dkms-remove.sh
@@ -30,12 +30,19 @@ SRC_DIR="/usr/src/${PKG_NAME}-${PKG_VER}"
 
 echo "==> Removing ${PKG_NAME} ${PKG_VER}"
 
-if [[ -n "$MOD_NAME" ]] && lsmod | grep -qw "$MOD_NAME"; then
+# A loaded module always has a /sys/module/<name> directory; check that
+# instead of `lsmod | grep -qw`, which has the same SIGPIPE-under-pipefail
+# race as the dkms-status check below.
+if [[ -n "$MOD_NAME" && -d "/sys/module/${MOD_NAME}" ]]; then
     echo "==> Unloading ${MOD_NAME}"
     modprobe -r "$MOD_NAME" || rmmod "$MOD_NAME" || true
 fi
 
-if dkms status | grep -qE "^${PKG_NAME}/${PKG_VER}"; then
+# Filter by name+version directly rather than piping `dkms status` into
+# `grep -q`; see the note in dkms-install.sh for why that pipeline was
+# unreliable (grep closing the pipe trips `set -o pipefail`, and the version
+# was an unescaped regex).
+if [[ -n "$(dkms status -m "${PKG_NAME}" -v "${PKG_VER}" 2>/dev/null || true)" ]]; then
     echo "==> dkms remove"
     dkms remove -m "${PKG_NAME}" -v "${PKG_VER}" --all || true
 fi


### PR DESCRIPTION
The install and remove scripts decided whether a DKMS entry existed by
piping `dkms status` into `grep -q`. That was unreliable for two reasons:

- `grep -q` closes the pipe on its first match, so `dkms status` gets
  SIGPIPE and exits non-zero. Under `set -o pipefail` the whole condition
  then evaluates false. With a short status the producer often finishes
  before grep exits, so it usually worked — but when it lost the race the
  install skipped its cleanup step and `dkms add` aborted with
  "DKMS tree already contains: rtl8852au/1.15.0.1".
- PACKAGE_VERSION was interpolated into the regex unescaped, so the dots in
  1.15.0.1 matched any character.

Both scripts now ask DKMS to filter by name and version directly
(`dkms status -m NAME -v VER`), which returns empty when the entry is
absent — no pipe, no regex, no race. The module-loaded check in the remove
script switches from `lsmod | grep -qw` to testing /sys/module/<name>, which
has the same pipe race and is the canonical way to detect a loaded module.

Reproduced the failure with a multi-line status stub under pipefail: the old
form matched 0/20 runs, the new form 20/20. shellcheck clean.
