### PR TITLE
ci: bump GitHub Pages actions to their current majors

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -43,10 +43,10 @@ jobs:
           find docs -maxdepth 1 -type f -printf '  %P\n'
 
       - name: Configure Pages
-        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b  # v5
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d  # v6.0.0
 
       - name: Upload docs/ as the Pages artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5.0.0
         with:
           path: docs
 
@@ -61,4 +61,4 @@ jobs:
     steps:
       - name: Deploy
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5.0.0


### PR DESCRIPTION
Combines Dependabot #35, #36 and #37 into one change so the three Pages
actions stay on a compatible set instead of landing one at a time:

- actions/upload-pages-artifact v3 -> v5.0.0
- actions/deploy-pages           v4 -> v5.0.0
- actions/configure-pages        v5 -> v6.0.0

upload-pages-artifact and deploy-pages must agree on the artifact format, so
bumping only one could break the landing-page deploy. All three SHAs verified
against their tags.
