### PR TITLE
fix: bump DKMS version to 1.16.0 and align kernel-range claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![CI](https://github.com/WimLee115/rtl8852au-build/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/WimLee115/rtl8852au-build/actions/workflows/ci.yml)
 [![Latest release](https://img.shields.io/github/v/release/WimLee115/rtl8852au-build?sort=semver&label=release&color=0a7ea4)](https://github.com/WimLee115/rtl8852au-build/releases/latest)
-[![Kernel](https://img.shields.io/badge/kernel-6.1%20%E2%80%93%207.0%2B-informational.svg)](#compatibility)
+[![Kernel](https://img.shields.io/badge/kernel-6.1%20%E2%80%93%207.0-informational.svg)](#compatibility)
 [![License: GPL-2.0](https://img.shields.io/badge/license-GPL--2.0-blue.svg)](LICENSE)
 [![DKMS](https://img.shields.io/badge/DKMS-supported-brightgreen.svg)](#dkms-install)
 [![WiFi 6](https://img.shields.io/badge/WiFi%206-AX1800-0a7ea4.svg)](#supported-devices)
@@ -28,8 +28,10 @@ upstream changes can be re-applied later.
 - **It builds on current kernels.** Twelve version-gated compatibility
   patches carry the vendor source across the 6.17+ API removals; CI
   compiles it against distro kernels *and* the latest kernel.org stable
-  and longterm releases, so post-6.18 breakage is caught before you hit
-  it. Verified up to **Linux 7.0**.
+  and longterm releases, so regressions on the supported line are caught
+  early. Verified up to **Linux 7.0.12**; **kernel 7.1 does not build
+  yet** — its cfg80211 callback refactor (net_device → wireless_dev)
+  needs separate porting work.
 - **Monitor mode that stays up.** Four separate fixes for the RX-path
   crashes that plagued the vendor driver — UBSAN out-of-bounds, a
   NULL-deref, an SKB use-after-free, and a race/double-free — plus a
@@ -264,7 +266,7 @@ sudo ./tests/run_tests.sh --all          # everything, including destructive
 | Ubuntu 22.04 LTS           | distro default     | x86_64  | CI build matrix     |
 | Ubuntu 24.04 LTS           | distro default     | x86_64  | CI build matrix     |
 
-Other kernels in the 6.1 LTS → 7.0+ range are expected to compile
+Other kernels in the 6.1 LTS → 7.0 range are expected to compile
 because every patch is gated on the relevant `LINUX_VERSION_CODE`, but
 they are not verified by the maintainer.
 

--- a/README.nl.md
+++ b/README.nl.md
@@ -4,7 +4,7 @@
 
 [![CI](https://github.com/WimLee115/rtl8852au-build/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/WimLee115/rtl8852au-build/actions/workflows/ci.yml)
 [![Nieuwste release](https://img.shields.io/github/v/release/WimLee115/rtl8852au-build?sort=semver&label=release&color=0a7ea4)](https://github.com/WimLee115/rtl8852au-build/releases/latest)
-[![Kernel](https://img.shields.io/badge/kernel-6.1%20%E2%80%93%207.0%2B-informational.svg)](#compatibiliteit)
+[![Kernel](https://img.shields.io/badge/kernel-6.1%20%E2%80%93%207.0-informational.svg)](#compatibiliteit)
 [![Licentie: GPL-2.0](https://img.shields.io/badge/licentie-GPL--2.0-blue.svg)](LICENSE)
 [![DKMS](https://img.shields.io/badge/DKMS-ondersteund-brightgreen.svg)](#dkms-installatie)
 [![WiFi 6](https://img.shields.io/badge/WiFi%206-AX1800-0a7ea4.svg)](#ondersteunde-apparaten)
@@ -29,8 +29,10 @@ kunnen worden.
 - **Hij bouwt op actuele kernels.** Twaalf versie-gegate
   compatibiliteitspatches dragen de vendor-broncode over de 6.17+
   API-verwijderingen; CI compileert tegen distro-kernels én de nieuwste
-  kernel.org stable- en longterm-releases, zodat breuk na 6.18 wordt
-  opgevangen vóór jij hem tegenkomt. Geverifieerd tot **Linux 7.0**.
+  kernel.org stable- en longterm-releases, zodat regressies op de
+  ondersteunde lijn vroeg worden opgevangen. Geverifieerd tot **Linux
+  7.0.12**; **kernel 7.1 bouwt nog niet** — de cfg80211-callback-refactor
+  (net_device → wireless_dev) vraagt apart porteerwerk.
 - **Monitor-mode die overeind blijft.** Vier aparte fixes voor de
   RX-path-crashes die de vendor-driver teisterden — UBSAN
   out-of-bounds, een NULL-deref, een SKB use-after-free en een
@@ -275,7 +277,7 @@ sudo ./tests/run_tests.sh --all          # alles, inclusief destructief
 | Ubuntu 22.04 LTS             | distributie-default | x86_64      | CI-bouw-matrix        |
 | Ubuntu 24.04 LTS             | distributie-default | x86_64      | CI-bouw-matrix        |
 
-Andere kernels in het bereik 6.1 LTS → 7.0+ worden verwacht te
+Andere kernels in het bereik 6.1 LTS → 7.0 worden verwacht te
 compileren omdat elke patch gebonden is aan een
 `LINUX_VERSION_CODE`-conditie, maar zijn niet door de maintainer
 geverifieerd.

--- a/dkms.conf
+++ b/dkms.conf
@@ -1,5 +1,5 @@
 PACKAGE_NAME="rtl8852au"
-PACKAGE_VERSION="1.15.0.1"
+PACKAGE_VERSION="1.16.0"
 MAKE="'make' -j$(nproc) KVER=$kernelver"
 CLEAN="'make' clean"
 BUILT_MODULE_NAME[0]="8852au"


### PR DESCRIPTION
dkms.conf still declared PACKAGE_VERSION 1.15.0.1 — the Realtek vendor
baseline — while the project has released v1.16.0 on its own SemVer line
(see RELEASE_NOTES_v1.16.0.md). A fresh install therefore registered under
the old vendor number, and the stale entry was a factor in the recent
"DKMS tree already contains" install collision. Bump it to 1.16.0 so the
DKMS package version matches the release.

Both READMEs advertised "kernel 6.1 → 7.0+" and claimed CI catches
"post-6.18 breakage before you hit it". Neither holds: the newest-stable CI
job is non-blocking, and kernel 7.1 does not build (the cfg80211 callbacks
moved from net_device to wireless_dev). The landing page already states this
honestly; the READMEs now match it — the "+" is gone and the 7.1 limitation
is named, with "verified up to Linux 7.0.12".

Vendor-provenance references to 1.15.0.1-2 are unchanged; only the DKMS
package version moves to the fork's SemVer line.
