### PR TITLE
fix(monitor): prevent NULL-deref panic when leaving monitor mode under RX load

### DIFF
--- a/core/monitor/rtw_radiotap.c
+++ b/core/monitor/rtw_radiotap.c
@@ -315,6 +315,35 @@ sint rtw_fill_radiotap_hdr(_adapter *padapter,
 	u8 hdr_buf[RTAP_HDR_MAX] = { 0 };
 	u16 rt_len = 8;
 
+	/* This runs in softirq context from the USB RX tasklet, so it cannot
+	 * take hw_init_mutex and may observe an interface teardown already in
+	 * progress on another CPU. netdev_close() calls rtw_hw_iface_deinit(),
+	 * which frees the wifi role and sets padapter->phl_role to NULL, while
+	 * every field read below dereferences it: the band via
+	 * WIFI_ROLE_IS_ON_24G(), the channel and bandwidth via
+	 * rtw_get_oper_ch() and rtw_get_oper_bw(). The netif_running() guard
+	 * in recv_frame_monitor() is evaluated before skb_copy_expand(), so it
+	 * cannot close this window. A NULL deref here faults in interrupt
+	 * context and is therefore a fatal panic, not a recoverable oops.
+	 * Drop the frame instead.
+	 */
+	if (padapter == NULL || padapter->dvobj == NULL
+	    || GET_PHL_COM(padapter->dvobj) == NULL
+	    || padapter->phl_role == NULL) {
+		static bool reported;
+
+		if (!reported) {
+			reported = true;
+			RTW_ERR("%s: dropping monitor frame - padapter=%p dvobj=%p phl_com=%p phl_role=%p\n",
+				 __func__, padapter,
+				 padapter ? padapter->dvobj : NULL,
+				 (padapter && padapter->dvobj) ? GET_PHL_COM(padapter->dvobj) : NULL,
+				 padapter ? padapter->phl_role : NULL);
+		}
+		ret = _FAIL;
+		return ret;
+	}
+
 	/* create header */
 	rtap_hdr = (struct ieee80211_radiotap_header *)&hdr_buf[0];
 	rtap_hdr->it_version = PKTHDR_RADIOTAP_VERSION;

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -2446,6 +2446,23 @@ static int netdev_close(struct net_device *pnetdev)
 		goto deinit;
 	}
 
+	/* A monitor-mode interface was never associated and holds no MLME
+	 * role — it is neither AP, STA, MESH nor ADHOC. Running the disassoc
+	 * path on it makes rtw_mlmeext_disconnect() fall through to its
+	 * rtw_warn_on(1) and hand MLME_ACTION_UNKNOWN to
+	 * rtw_dfs_rd_en_decision(), which warns a second time. Beyond the log
+	 * noise this keeps the close path busy for up to ~700 ms
+	 * (rtw_disassoc_cmd WAIT_ACK plus the scan-req drain) while the RX
+	 * tasklet still delivers frames into the radiotap path, widening the
+	 * window in which it can observe half-torn-down state. There is
+	 * nothing to disconnect: go straight to deinit.
+	 */
+	if (MLME_IS_MONITOR(padapter)) {
+		RTW_INFO(FUNC_NDEV_FMT" monitor mode — skipping disassoc cmds\n",
+			 FUNC_NDEV_ARG(pnetdev));
+		goto deinit;
+	}
+
 	if (pwrctl->rf_pwrstate == rf_on) {
 		RTW_INFO("netif_up=%d, hw_init_completed=%s\n",
 			padapter->netif_up,

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -22,6 +22,7 @@ Safety:
 import argparse
 import subprocess
 import os
+import shutil
 import sys
 import time
 import re
@@ -503,6 +504,77 @@ class TestStability(unittest.TestCase):
             time.sleep(2)
         rc, out, _ = run(f"iw dev {self.iface} scan dump", timeout=15)
         self.assertEqual(rc, 0, "Scan dump failed after multiple triggers")
+
+    def test_03_monitor_teardown_under_rx_load(self):
+        """Regression: leave monitor mode while the RX path is still live.
+
+        rtw_fill_radiotap_hdr() dereferences padapter->phl_role for the
+        band, channel and bandwidth fields. netdev_close() clears that
+        pointer through rtw_hw_iface_deinit() while the USB RX tasklet can
+        still be inside recv_frame_monitor(): the netif_running() guard
+        there is evaluated before skb_copy_expand(), so it does not cover
+        the radiotap fill that follows. Observed in the field as
+
+            BUG: kernel NULL pointer dereference, address: 0x4e8
+            RIP: rtw_fill_radiotap_hdr+0x1cf [8852au]
+            Kernel panic - not syncing: Fatal exception in interrupt
+
+        after a 300 s airodump-ng capture, where 0x4e8 is chandef.band
+        inside the freed rtw_wifi_role_t. The fault lands in interrupt
+        context, so it is always fatal rather than a recoverable oops.
+
+        This cycles monitor -> managed with frames still arriving and a
+        capture socket still open, which is the ordering that crashed.
+        Surviving the loop is the pass condition.
+        """
+        iface = self.iface
+        sniffer = None
+
+        try:
+            for _ in range(5):
+                run(f"ip link set {iface} down", timeout=10)
+                rc, _, err = run(f"iw dev {iface} set type monitor", timeout=10)
+                self.assertEqual(rc, 0, f"could not enter monitor mode: {err}")
+                run(f"ip link set {iface} up", timeout=10)
+
+                # Park on a busy 2.4 GHz channel so beacons keep the RX
+                # tasklet inside the radiotap path during the teardown.
+                run(f"iw dev {iface} set channel 1", timeout=10)
+
+                if shutil.which("tcpdump"):
+                    sniffer = subprocess.Popen(
+                        ["tcpdump", "-i", iface, "-w", os.devnull, "-U"],
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
+                    )
+                time.sleep(3)
+
+                # Signal the sniffer but do NOT reap it: the packet socket
+                # stays open across netdev_close(), which is exactly the
+                # window the panic needed.
+                if sniffer:
+                    sniffer.terminate()
+
+                run(f"ip link set {iface} down", timeout=10)
+                rc, _, err = run(f"iw dev {iface} set type managed", timeout=10)
+                self.assertEqual(rc, 0, f"could not leave monitor mode: {err}")
+                run(f"ip link set {iface} up", timeout=10)
+                time.sleep(1.5)
+
+                if sniffer:
+                    sniffer.kill()
+                    sniffer.wait(timeout=5)
+                    sniffer = None
+        finally:
+            if sniffer and sniffer.poll() is None:
+                sniffer.kill()
+            run(f"ip link set {iface} down", timeout=10)
+            run(f"iw dev {iface} set type managed", timeout=10)
+            run(f"ip link set {iface} up", timeout=10)
+
+        rc, out, _ = run(f"iw dev {iface} info", timeout=10)
+        self.assertEqual(rc, 0, "Interface broken after monitor teardown cycles")
+        self.assertIn("type managed", out, "Interface did not return to managed")
 
 
 def generate_report(result):


### PR DESCRIPTION
## Problem

`rtw_fill_radiotap_hdr()` runs in softirq context from the USB RX tasklet and
dereferences `padapter->phl_role` for the band, channel and bandwidth fields.
`netdev_close()` clears that pointer through `rtw_hw_iface_deinit()` while the
tasklet can still be inside `recv_frame_monitor()`: the `netif_running()` guard
there is evaluated *before* `skb_copy_expand()`, so it does not cover the
radiotap fill that follows.

The result is a fatal in-interrupt NULL dereference after long `airodump-ng`
captures:

```
BUG: kernel NULL pointer dereference, address: 0x4e8
RIP: rtw_fill_radiotap_hdr+0x1cf [8852au]
Kernel panic - not syncing: Fatal exception in interrupt
```

`0x4e8` is `chandef.band` inside the freed `rtw_wifi_role_t`. Because the fault
lands in interrupt context it is always fatal rather than a recoverable oops.

## Changes

- **core/monitor/rtw_radiotap.c** — bail out and drop the frame when
  `padapter` / `dvobj` / `phl_com` / `phl_role` is NULL, with a rate-limited
  one-shot diagnostic so the drop is visible without flooding the log.
- **os_dep/linux/os_intfs.c** — in `netdev_close()`, skip the disassoc command
  path for a monitor interface (`MLME_IS_MONITOR`). A monitor interface holds
  no MLME role to disconnect, and the ~700 ms `WAIT_ACK` plus scan-req drain
  only widens the window in which the RX tasklet observes half-torn-down state.
- **tests/test_driver.py** — regression test that leaves monitor mode while the
  RX path is still live (capture socket open, frames arriving), which is the
  ordering that crashed.

## Verification

- Builds clean against kernel 7.0.12 — 0 errors, no new compiler warnings.
- `ruff` and `pyflakes` pass on the test addition.
