### PR TITLE
release: v1.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,58 @@ changes in this file.
 
 ## [Unreleased]
 
-### Removed
-- `tools/tapo_rtsp_brute.py` and the whole `tools/` directory. The RTSP
-  credential brute-forcer was unrelated to the WiFi driver and out of scope
-  for this repository; its CI compile-check, its ruff per-file ignore and its
-  entry in the architecture docs are removed along with it.
+## [1.16.1] — 2026-08-18
+
+A maintenance release on top of `1.16.0`: one monitor-mode kernel panic, three
+DKMS packaging faults, and a test suite that reported failures against
+perfectly healthy installs.
 
 ### Fixed
+
+- **Kernel panic when leaving monitor mode under RX load.**
+  `rtw_fill_radiotap_hdr()` runs in softirq from the USB RX tasklet and
+  dereferences `padapter->phl_role` for the band, channel and bandwidth
+  fields. `netdev_close()` clears that pointer through
+  `rtw_hw_iface_deinit()` while the tasklet can still be inside
+  `recv_frame_monitor()` — the `netif_running()` guard there is evaluated
+  before `skb_copy_expand()`, so it does not cover the radiotap fill that
+  follows. The result was a fatal in-interrupt NULL deref (fault address
+  `0x4e8` = `chandef.band` in the freed `rtw_wifi_role_t`) after long
+  `airodump-ng` captures. The radiotap path now bails out and drops the frame
+  when any of `padapter`/`dvobj`/`phl_com`/`phl_role` is NULL, and
+  `netdev_close()` skips the disassoc path for a monitor interface, which
+  holds no MLME role to disconnect and whose ~700 ms `WAIT_ACK` only widened
+  the teardown race. Regression test included.
+- **DKMS status checks were racy and matched too loosely.** Both install and
+  remove scripts piped `dkms status` into `grep -q`, which closes the pipe on
+  its first match; `dkms status` then takes SIGPIPE and exits non-zero, so
+  under `set -o pipefail` the whole condition evaluated false. When it lost
+  that race the install skipped its cleanup and `dkms add` aborted with
+  "DKMS tree already contains". `PACKAGE_VERSION` was also interpolated into
+  the regex unescaped, so the dots in a version matched any character. Both
+  scripts now let DKMS filter directly (`dkms status -m NAME -v VER`), and the
+  module-loaded check tests `/sys/module/<name>` instead of piping `lsmod`.
+  Reproduced under `pipefail` with a multi-line status stub: the old form
+  matched 0/20 runs, the new form 20/20.
+- **DKMS registered under the vendor version.** `dkms.conf` still declared
+  `PACKAGE_VERSION` `1.15.0.1` — the Realtek baseline — while the project had
+  released `1.16.0` on its own SemVer line, so a fresh install registered
+  under the old number. That stale entry was a factor in the install collision
+  above.
+- **A version bump orphaned the previous DKMS entry.** Both scripts acted only
+  on the version `dkms.conf` currently names, so upgrading left the old entry
+  registered — and two entries then install the same `8852au.ko` into
+  `/updates/dkms` on every kernel upgrade. Worse, `dkms-remove.sh` could no
+  longer remove the orphan at all, since the checked-out `dkms.conf` no longer
+  matched it. Both scripts now enumerate every registered version of the
+  package and clear them, and `dkms-remove.sh` also sweeps the matching
+  `/usr/src/<name>-*` trees. The version parser accepts DKMS 2.x and 3.x
+  output as well as an "added"-only entry that carries no kernel/arch fields.
+- **Kernel-range claims corrected.** Both READMEs advertised "kernel
+  6.1 → 7.0+" and claimed CI catches post-6.18 breakage before you hit it.
+  Neither held: the newest-stable CI job is non-blocking, and kernel 7.1 does
+  not build. The "+" is gone and the 7.1 limitation is named, with "verified
+  up to Linux 7.0.12".
 - **The test suite no longer fails on a working DKMS install.**
   `tests/test_driver.py` hard-coded the module path to `<repo>/8852au.ko`, so
   anyone who installed with `./dkms-install.sh` — the method the README
@@ -44,6 +89,14 @@ changes in this file.
   module-path parsing above, and a CI step that runs it. Every other class in
   the suite needs a physical adapter, so this logic previously had no
   automated coverage at all.
+- `./tests/run_tests.sh --offline` selects that class from the runner — the
+  one selection that is meaningful without an adapter or root.
+
+### Removed
+- `tools/tapo_rtsp_brute.py` and the whole `tools/` directory. The RTSP
+  credential brute-forcer was unrelated to the WiFi driver and out of scope
+  for this repository; its CI compile-check, its ruff per-file ignore and its
+  entry in the architecture docs are removed along with it.
 
 ## [1.16.0] — 2026-08-01
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -21,6 +21,10 @@ is generated automatically from commit history.
 - **[74Thirsty — `gadgetsaavy`](https://github.com/74Thirsty)** — D-Link
   DWA-1850 USB ID (`2001:332c`) and Parrot OS 6/7 testing
   ([PR #14](https://github.com/WimLee115/rtl8852au-build/pull/14)).
+- **[Omelug](https://github.com/Omelug)** — hardware report for `0bda:8832`
+  on kernel 7.0.12, which surfaced two test-suite bugs: the module path was
+  hard-coded to an in-tree build, and adapters behind a USB hub read as
+  unbound ([issue #43](https://github.com/WimLee115/rtl8852au-build/issues/43)).
 
 ## Acknowledgements
 

--- a/CONTRIBUTORS.nl.md
+++ b/CONTRIBUTORS.nl.md
@@ -21,6 +21,11 @@ wordt automatisch gegenereerd uit de commit-historie.
 - **[74Thirsty — `gadgetsaavy`](https://github.com/74Thirsty)** — D-Link
   DWA-1850 USB-ID (`2001:332c`) en testen op Parrot OS 6/7
   ([PR #14](https://github.com/WimLee115/rtl8852au-build/pull/14)).
+- **[Omelug](https://github.com/Omelug)** — hardwarerapport voor `0bda:8832`
+  op kernel 7.0.12, waarmee twee bugs in de test suite aan het licht kwamen:
+  het modulepad was hardgecodeerd op een in-tree build, en adapters achter
+  een USB-hub golden als niet-gebonden
+  ([issue #43](https://github.com/WimLee115/rtl8852au-build/issues/43)).
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -404,6 +404,9 @@ driver-source patches. In short:
   Archer TX35U Plus USB ID and the kernel 6.8 build fix (PR #3).
 - **[74Thirsty (`gadgetsaavy`)](https://github.com/74Thirsty)** — D-Link
   DWA-1850 USB ID `2001:332c` and Parrot OS 6/7 testing (PR #14).
+- **[Omelug](https://github.com/Omelug)** — hardware report for
+  `0bda:8832` that surfaced the DKMS module-path and USB-hub binding
+  bugs in the test suite (issue #43).
 - **[WimLee115](https://github.com/WimLee115)** — fork maintenance,
   kernel-compatibility patches, test suite, dashboard.
 

--- a/README.nl.md
+++ b/README.nl.md
@@ -437,6 +437,9 @@ Zoals bij elke out-of-tree-kernelmodule wordt de software
   Archer TX35U Plus USB-ID en de kernel 6.8-buildfix (PR #3).
 - **[74Thirsty (`gadgetsaavy`)](https://github.com/74Thirsty)** — D-Link
   DWA-1850 USB-ID `2001:332c` en testen op Parrot OS 6/7 (PR #14).
+- **[Omelug](https://github.com/Omelug)** — hardwarerapport voor
+  `0bda:8832` dat de bugs met het DKMS-modulepad en USB-hub-binding in
+  de test suite aan het licht bracht (issue #43).
 - **[WimLee115](https://github.com/WimLee115)** — fork-onderhoud,
   kernel-compatibiliteit-patches, test suite, dashboard.
 

--- a/RELEASE_NOTES_v1.16.0.md
+++ b/RELEASE_NOTES_v1.16.0.md
@@ -57,5 +57,3 @@ Realtek (original vendor driver), [lwfinger](https://github.com/lwfinger) and [m
 ---
 
 **Disclaimer.** Independent community fork — not affiliated with, endorsed by, or sponsored by Realtek Semiconductor Corp. or any hardware vendor named here. The firmware blob is © Realtek, redistributed unchanged from the vendor bundle and checksum-verified in CI. Released under the **GNU GPL-2.0**, provided "AS IS" without warranty of any kind.
-
-<sub>🤖 Release notes drafted with [Claude Code](https://claude.com/claude-code)</sub>

--- a/RELEASE_NOTES_v1.16.1.md
+++ b/RELEASE_NOTES_v1.16.1.md
@@ -1,0 +1,83 @@
+# rtl8852au-build v1.16.1
+
+**Maintenance release.** One monitor-mode kernel panic, three DKMS packaging faults, and a test suite that reported failures against perfectly healthy installs.
+
+🌐 **Website & docs:** https://wimlee115.github.io/rtl8852au-build/
+
+---
+
+## What's fixed
+
+### Kernel panic when leaving monitor mode under RX load
+
+`rtw_fill_radiotap_hdr()` runs in softirq from the USB RX tasklet and dereferences `padapter->phl_role` for the band, channel and bandwidth fields. `netdev_close()` clears that pointer through `rtw_hw_iface_deinit()` while the tasklet can still be inside `recv_frame_monitor()` — the `netif_running()` guard there is evaluated *before* `skb_copy_expand()`, so it does not cover the radiotap fill that follows.
+
+In the field this showed up after long `airodump-ng` captures:
+
+```
+BUG: kernel NULL pointer dereference, address: 0x4e8
+RIP: rtw_fill_radiotap_hdr+0x1cf [8852au]
+Kernel panic - not syncing: Fatal exception in interrupt
+```
+
+`0x4e8` is `chandef.band` inside the freed `rtw_wifi_role_t`. The fault lands in interrupt context, so it is always fatal rather than a recoverable oops. The radiotap path now drops the frame when any of `padapter`/`dvobj`/`phl_com`/`phl_role` is NULL, and `netdev_close()` skips the disassoc path for a monitor interface — it holds no MLME role to disconnect, and the ~700 ms `WAIT_ACK` only widened the teardown race. A regression test cycles monitor → managed under live RX with a capture socket open.
+
+### DKMS install could abort with "DKMS tree already contains"
+
+Both DKMS scripts piped `dkms status` into `grep -q`, which closes the pipe on its first match. `dkms status` then takes SIGPIPE and exits non-zero, so under `set -o pipefail` the whole condition evaluated false — and when it lost that race, the install skipped its cleanup and `dkms add` aborted. `PACKAGE_VERSION` was also interpolated into the regex unescaped, so the dots matched any character. Both scripts now let DKMS filter directly (`dkms status -m NAME -v VER`), with no pipe, no regex and no race. Reproduced under `pipefail` with a multi-line status stub: the old form matched 0/20 runs, the new form 20/20.
+
+`dkms.conf` also still declared the Realtek baseline version `1.15.0.1` while the project had released `1.16.0`, so a fresh install registered under the old number — a factor in the collision above. It now tracks the release version.
+
+### The test suite no longer fails on a healthy install
+
+Reported in [#43](https://github.com/WimLee115/rtl8852au-build/issues/43), where five failures against a working `0bda:8832` adapter all turned out to be test-suite artefacts:
+
+- **Module path was hard-coded** to `<repo>/8852au.ko`, so a DKMS install — the method the README recommends — failed three tests purely because the module sits in `/lib/modules/<release>/updates/dkms/` and is xz-compressed. The path now resolves at run time: in-tree build first (so a stale build still reports a genuine srcversion mismatch), then `modinfo -n`, then the DKMS directory.
+- **Adapters behind a USB hub read as unbound.** The sysfs pattern only covered a device on a root port (`1-2:1.0`); behind a hub the port path is dot-separated (`1-8.4:1.0`, `2-1.4.3:1.0` when chained).
+- **An empty scan counted as a failure.** Zero BSSes is not evidence of a fault — an rfkill block or a shielded room give the same result — so it now skips with the reason and hard-fails only when the scan mechanism itself errors.
+
+A new hardware-free test class covers this parsing and runs in CI, reachable as `./tests/run_tests.sh --offline`. Every other class in the suite needs a physical adapter, which is why the gap stayed invisible.
+
+## Upgrade
+
+```bash
+cd rtl8852au-build
+git pull
+sudo ./dkms-install.sh
+```
+
+The install script now clears **every** registered version of the package
+before adding the new one, so the upgrade leaves exactly one DKMS entry
+behind. Previously it only cleared the version `dkms.conf` currently named,
+which meant a version bump orphaned the old entry — and two entries then
+raced to install the same `8852au.ko` into `/updates/dkms` on every kernel
+upgrade. If you are upgrading from `1.16.0`, that cleanup happens for you;
+verify with `dkms status -m rtl8852au`.
+
+A plain `make` install is unchanged:
+
+```bash
+make -j"$(nproc)" && sudo make install && sudo modprobe 8852au
+```
+
+## Verified
+
+- **Green across the CI matrix**: Ubuntu 22.04 and 24.04 distro kernels, mainline longterm and stable from kernel.org, DKMS install/remove dry-run, ruff/pyflakes lint, and CodeQL.
+- **Monitor-mode fix built clean against Linux 7.0.12** and validated on hardware.
+- **Test-suite fix reproduced and verified** on a Kali 7.0.12 system in the reporter's exact configuration (DKMS install, no in-tree build): the affected tests failed on `1.16.0` and pass on this release.
+
+## Known limitations
+
+- **Kernel 7.1 is not yet supported.** 7.1 refactored a large set of `cfg80211_ops` callbacks from `net_device` to `wireless_dev`, which breaks the station/key callbacks. Kernels up to and including **7.0** build cleanly; verified up to Linux 7.0.12. A version-gated port is tracked as follow-up work.
+
+## Supported devices
+
+RTL8852AU / RTL8832AU USB adapters — 15 USB IDs across TP-Link, ASUS, D-Link, Buffalo, Elecom and the Realtek reference boards. Full table: [supported devices](https://github.com/WimLee115/rtl8852au-build/blob/main/README.md#supported-devices). Have one working that's only *Recognised*? [Send an `lsusb -v` report](https://github.com/WimLee115/rtl8852au-build/issues/new?template=hardware_support.yml) and it moves to *Tested*.
+
+## Credits
+
+Realtek (original vendor driver), [lwfinger](https://github.com/lwfinger) and [morrownr](https://github.com/morrownr) (community packaging & USB-ID references), [jsiwrk](https://github.com/jsiwrk) (TP-Link Archer TX35U Plus USB ID and the kernel 6.8 build fix, PR #3), [74Thirsty](https://github.com/74Thirsty) (D-Link DWA-1850 USB ID `2001:332c` and Parrot OS 6/7 testing, PR #14), and [Omelug](https://github.com/Omelug) (hardware report that surfaced both test-suite bugs in this release, issue #43).
+
+---
+
+**Disclaimer.** Independent community fork — not affiliated with, endorsed by, or sponsored by Realtek Semiconductor Corp. or any hardware vendor named here. The firmware blob is © Realtek, redistributed unchanged from the vendor bundle and checksum-verified in CI. Released under the **GNU GPL-2.0**, provided "AS IS" without warranty of any kind.

--- a/dkms-install.sh
+++ b/dkms-install.sh
@@ -39,6 +39,18 @@ fi
 
 SRC_DIR="/usr/src/${PKG_NAME}-${PKG_VER}"
 
+# Every version of $1 that DKMS currently knows about, one per line.
+#
+# `dkms status` prints "name/version, kernel, arch: state" on DKMS 3.x and
+# "name, version, kernel, arch: state" on 2.x, and drops the kernel/arch part
+# entirely for an entry that is only "added" — so accept either separator and
+# stop at the first comma or colon.
+dkms_versions() {
+    dkms status -m "$1" 2>/dev/null \
+        | sed -n "s|^$1[/,] *\([^,:]*\).*|\1|p" \
+        | sort -u
+}
+
 # Sanity checks for build dependencies
 for cmd in dkms make gcc; do
     if ! command -v "$cmd" >/dev/null 2>&1; then
@@ -55,19 +67,29 @@ fi
 
 echo "==> Installing ${PKG_NAME} ${PKG_VER} via DKMS"
 
-# Remove any stale registration for this name+version (idempotent re-run).
+# Remove every existing registration for this package, at any version.
 #
-# Ask DKMS to filter by name+version directly instead of piping `dkms status`
-# into `grep -q`. That pipeline had two bugs: (1) `grep -q` closes the pipe on
-# its first match, sending SIGPIPE to `dkms status`, which under `set -o
-# pipefail` makes the whole condition fail — so the stale entry silently
-# survived and the later `dkms add` collided with "module/version already in
-# the tree"; (2) PACKAGE_VERSION was used unescaped in a regex, so the dots in
-# 1.15.0.1 matched any character. Filtering server-side sidesteps both.
-if [[ -n "$(dkms status -m "${PKG_NAME}" -v "${PKG_VER}" 2>/dev/null || true)" ]]; then
-    echo "==> Removing existing DKMS entry ${PKG_NAME}/${PKG_VER}"
-    dkms remove -m "${PKG_NAME}" -v "${PKG_VER}" --all || true
-fi
+# Ask DKMS for the list instead of piping `dkms status` into `grep -q`. That
+# pipeline had two bugs: (1) `grep -q` closes the pipe on its first match,
+# sending SIGPIPE to `dkms status`, which under `set -o pipefail` makes the
+# whole condition fail — so the stale entry silently survived and the later
+# `dkms add` collided with "module/version already in the tree"; (2)
+# PACKAGE_VERSION was used unescaped in a regex, so the dots in 1.15.0.1
+# matched any character.
+#
+# Matching on name+version alone was still not enough: on a version bump the
+# *previous* version stayed registered, and both entries then install the same
+# 8852au.ko into /updates/dkms on every kernel upgrade. Clearing all versions
+# makes an upgrade leave exactly one entry behind.
+for stale_ver in $(dkms_versions "${PKG_NAME}"); do
+    echo "==> Removing existing DKMS entry ${PKG_NAME}/${stale_ver}"
+    dkms remove -m "${PKG_NAME}" -v "${stale_ver}" --all || true
+    stale_src="/usr/src/${PKG_NAME}-${stale_ver}"
+    if [[ -d "$stale_src" && "$stale_src" != "$SRC_DIR" ]]; then
+        echo "==> Removing ${stale_src}"
+        rm -rf "$stale_src"
+    fi
+done
 
 echo "==> Copying source to ${SRC_DIR}"
 rm -rf "${SRC_DIR}"

--- a/dkms-remove.sh
+++ b/dkms-remove.sh
@@ -28,7 +28,18 @@ MOD_NAME="$(awk -F'"' '/^BUILT_MODULE_NAME\[0\]=/{print $2}' dkms.conf)"
 
 SRC_DIR="/usr/src/${PKG_NAME}-${PKG_VER}"
 
-echo "==> Removing ${PKG_NAME} ${PKG_VER}"
+# See the note in dkms-install.sh: accept either separator, and stop at the
+# first comma or colon so an "added"-only entry parses too.
+# Trailing `|| true`: this script has no dkms sanity check, and removal is
+# best-effort — a missing dkms should not abort the module unload and the
+# /usr/src cleanup that follow.
+dkms_versions() {
+    dkms status -m "$1" 2>/dev/null \
+        | sed -n "s|^$1[/,] *\([^,:]*\).*|\1|p" \
+        | sort -u || true
+}
+
+echo "==> Removing ${PKG_NAME}"
 
 # A loaded module always has a /sys/module/<name> directory; check that
 # instead of `lsmod | grep -qw`, which has the same SIGPIPE-under-pipefail
@@ -38,19 +49,26 @@ if [[ -n "$MOD_NAME" && -d "/sys/module/${MOD_NAME}" ]]; then
     modprobe -r "$MOD_NAME" || rmmod "$MOD_NAME" || true
 fi
 
-# Filter by name+version directly rather than piping `dkms status` into
-# `grep -q`; see the note in dkms-install.sh for why that pipeline was
-# unreliable (grep closing the pipe trips `set -o pipefail`, and the version
-# was an unescaped regex).
-if [[ -n "$(dkms status -m "${PKG_NAME}" -v "${PKG_VER}" 2>/dev/null || true)" ]]; then
-    echo "==> dkms remove"
-    dkms remove -m "${PKG_NAME}" -v "${PKG_VER}" --all || true
-fi
+# Ask DKMS for the list rather than piping `dkms status` into `grep -q`; see
+# the note in dkms-install.sh for why that pipeline was unreliable (grep
+# closing the pipe trips `set -o pipefail`, and the version was an unescaped
+# regex).
+#
+# Remove every version, not just the one dkms.conf currently names: after a
+# version bump the checked-out dkms.conf no longer matches the entry that is
+# actually installed, so a name+version match would leave it behind with no
+# way to remove it from this script at all.
+for ver in $(dkms_versions "${PKG_NAME}"); do
+    echo "==> dkms remove ${PKG_NAME}/${ver}"
+    dkms remove -m "${PKG_NAME}" -v "${ver}" --all || true
+done
 
-if [[ -d "$SRC_DIR" ]]; then
-    echo "==> Removing ${SRC_DIR}"
-    rm -rf "$SRC_DIR"
-fi
+for src in "/usr/src/${PKG_NAME}"-*; do
+    if [[ -d "$src" ]]; then
+        echo "==> Removing ${src}"
+        rm -rf "$src"
+    fi
+done
 
 depmod -a
 

--- a/dkms-remove.sh
+++ b/dkms-remove.sh
@@ -22,11 +22,12 @@ if [[ ! -f dkms.conf ]]; then
     exit 1
 fi
 
+# PACKAGE_VERSION is deliberately not read here: this script removes every
+# registered version of the package, so the one dkms.conf happens to name is
+# not the right thing to key off — after a version bump it is precisely the
+# version that is *not* installed.
 PKG_NAME="$(awk -F'"' '/^PACKAGE_NAME=/{print $2}' dkms.conf)"
-PKG_VER="$(awk -F'"' '/^PACKAGE_VERSION=/{print $2}' dkms.conf)"
 MOD_NAME="$(awk -F'"' '/^BUILT_MODULE_NAME\[0\]=/{print $2}' dkms.conf)"
-
-SRC_DIR="/usr/src/${PKG_NAME}-${PKG_VER}"
 
 # See the note in dkms-install.sh: accept either separator, and stop at the
 # first comma or colon so an "added"-only entry parses too.

--- a/dkms.conf
+++ b/dkms.conf
@@ -1,5 +1,5 @@
 PACKAGE_NAME="rtl8852au"
-PACKAGE_VERSION="1.16.0"
+PACKAGE_VERSION="1.16.1"
 MAKE="'make' -j$(nproc) KVER=$kernelver"
 CLEAN="'make' clean"
 BUILT_MODULE_NAME[0]="8852au"


### PR DESCRIPTION
Maintenance release on top of `1.16.0`.

## Changelog catch-up

Five changes landed on `main` after the `1.16.0` tag, but only the `tools/`
removal had reached the changelog. The rest are written up here for the first
time:

| PR | What |
|---|---|
| #42 | Monitor-mode NULL-deref kernel panic under RX load |
| #38 | DKMS status checks were racy under `pipefail` and matched too loosely |
| #40 | DKMS package version bump + honest kernel-range claims |
| #41 | `tools/` removal |
| #44 | Test suite failed on DKMS installs and hub-attached adapters |

## New in this PR: a DKMS upgrade fault

This release would have been the first to trigger it. Both DKMS scripts acted
only on the version `dkms.conf` currently names, so bumping `1.16.0` →
`1.16.1` leaves the old entry registered — and two entries then install the
same `8852au.ko` into `/updates/dkms` on every kernel upgrade.
`dkms-remove.sh` could not clear the orphan either, because the checked-out
`dkms.conf` no longer matched it.

This machine is in exactly that state:

```
$ dkms status -m rtl8852au
rtl8852au/1.16.0, 7.0.12+kali-amd64, x86_64: installed
```

Both scripts now enumerate every registered version and clear them;
`dkms-remove.sh` also sweeps the matching `/usr/src/<name>-*` trees. The
version parser was checked against all four shapes DKMS emits:

| `dkms status` line | parsed |
|---|---|
| `rtl8852au/1.16.0, 7.0.12+kali-amd64, x86_64: installed` (3.x) | `1.16.0` |
| `rtl8852au, 1.16.0, 7.0.12, x86_64: installed` (2.x) | `1.16.0` |
| `rtl8852au/1.16.0: added` (no kernel/arch) | `1.16.0` |
| `rtl8852au/1.15.0.1, 6.19.14, x86_64: built` | `1.15.0.1` |

Exercised end-to-end with a stub standing in for `dkms`: both the install and
remove flows now clear `1.15.0.1` **and** `1.16.0`. `dkms-remove.sh` keeps
working when `dkms` is absent entirely, as it did before.

## Credits

@Omelug is credited in both READMEs and both CONTRIBUTORS files for the
hardware report (#43) that surfaced the two test-suite bugs.

`0bda:8832` stays **Recognised** rather than moving to **Tested**: the report
ticked *"driver loads but doesn't connect"* while its prose said connection
and monitor mode both worked. I have asked for confirmation on #43 and will
promote it once that comes back.

## Housekeeping

Dropped the tooling footer line from `RELEASE_NOTES_v1.16.0.md`.

## Checks

`bash -n` on all three shell scripts, ruff + `py_compile` on the Python, and
the offline test class — all clean locally.
