### PR TITLE
ci: run the build matrix weekly, not only on push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,18 @@ on:
   pull_request:
     branches: [main]
   workflow_dispatch:
+  # Weekly, Monday 05:17 UTC.
+  #
+  # The build-mainline job resolves the newest kernel.org stable and longterm
+  # releases at run time, so what it tests changes without anyone touching
+  # this repository — and on a push-only trigger a quiet week means no signal
+  # at all. A new LTS that breaks the build is a hard failure worth an email
+  # the week it lands, not whenever the next commit happens to arrive.
+  #
+  # Monday because Linus cuts releases on Sunday. Off the hour because
+  # scheduled runs cluster (and get delayed) at :00.
+  schedule:
+    - cron: "17 5 * * 1"
 
 permissions:
   contents: read
@@ -152,11 +164,17 @@ jobs:
           # that to a warning — this is a compile/link test, and real
           # source-level breakage is already caught in the compile phase
           # before modpost runs.
+          # Record which kernel this job actually resolved, whatever the
+          # outcome. On the weekly schedule the version moves on its own, so a
+          # bare green tick does not say what was tested — and when a run does
+          # go red, the first question is always "against which kernel?".
+          chan="${{ matrix.channel }}"
           set -o pipefail
           if make KVER="${krel}" KBUILD_MODPOST_WARN=1 -j"$(nproc)" 2>&1 | tee build-mainline.log && test -f 8852au.ko; then
             echo "Module built successfully against ${ver}."
             modinfo ./8852au.ko | grep -E "vermagic|^version" || true
-          elif [ "${{ matrix.channel }}" = "stable" ]; then
+            echo "✅ **\`${chan}\`** — builds against Linux \`${ver}\`" >> "$GITHUB_STEP_SUMMARY"
+          elif [ "$chan" = "stable" ]; then
             # Newest-stable is a forward-looking probe: report loudly, but do
             # not fail the job — otherwise every branch shows a red X for a
             # known limitation.
@@ -167,6 +185,8 @@ jobs:
             } >> "$GITHUB_STEP_SUMMARY"
           else
             echo "::error title=LTS ${ver} does not build::The driver failed to build against the longterm/LTS kernel ${ver}."
+            echo "### ❌ Longterm \`${ver}\` does not build" >> "$GITHUB_STEP_SUMMARY"
+            echo "This is a regression gate — the LTS kernel must build." >> "$GITHUB_STEP_SUMMARY"
             exit 1
           fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ changes in this file.
 
 ## [Unreleased]
 
+### Added
+- **CI runs weekly on a schedule** (Mondays, 05:17 UTC) in addition to push
+  and pull-request triggers. The `build-mainline` job resolves the newest
+  kernel.org stable and longterm releases at run time, so what it tests moves
+  on its own — on a push-only trigger a quiet week produced no signal at all,
+  and a new LTS that broke the build would sit undetected until the next
+  commit. Monday because Linus cuts releases on Sunday; off the hour because
+  scheduled runs cluster and get delayed at `:00`.
+
+### Changed
+- **`build-mainline` now records the kernel it resolved** in the job summary,
+  on success as well as failure. A bare green tick did not say which version
+  was actually tested, which is precisely the question a scheduled run raises.
+
 ## [1.16.1] — 2026-08-18
 
 A maintenance release on top of `1.16.0`: one monitor-mode kernel panic, three

--- a/README.md
+++ b/README.md
@@ -275,6 +275,13 @@ Other kernels in the 6.1 LTS → 7.0 range are expected to compile
 because every patch is gated on the relevant `LINUX_VERSION_CODE`, but
 they are not verified by the maintainer.
 
+CI also builds against the newest kernel.org **longterm** and **stable**
+releases, resolved at run time, on every push *and* weekly on a schedule —
+so a new LTS that breaks the build surfaces the week it lands rather than
+whenever the next commit happens to arrive. Longterm is a hard gate;
+newest-stable is an informational early warning, currently expected to fail
+on kernel 7.1.
+
 ## Troubleshooting
 
 <details>

--- a/README.nl.md
+++ b/README.nl.md
@@ -287,6 +287,13 @@ compileren omdat elke patch gebonden is aan een
 `LINUX_VERSION_CODE`-conditie, maar zijn niet door de maintainer
 geverifieerd.
 
+CI bouwt daarnaast tegen de nieuwste **longterm**- en **stable**-releases van
+kernel.org, tijdens de run opgehaald, bij elke push *én* wekelijks volgens
+schema — zo komt een nieuwe LTS die de build breekt aan het licht in de week
+dat hij uitkomt, in plaats van pas bij de volgende commit. Longterm is een
+harde poort; nieuwste-stable is een informatieve vroege waarschuwing, die op
+kernel 7.1 momenteel faalt.
+
 ## Probleemoplossing
 
 <details>


### PR DESCRIPTION
Closes the last open item from the post-holiday sweep.

## Why

`build-mainline` resolves the newest kernel.org stable and longterm releases
**at run time**, so what it tests changes without anyone touching this
repository. On a push-only trigger that means a quiet week produces no signal
at all — a new LTS that breaks the build would sit undetected until the next
commit happened to arrive.

That is not hypothetical: the last CI run before this sweep was 4 August, so
the driver went two weeks without being built against a current mainline
kernel. CodeQL already runs weekly; CI did not.

## What

A weekly schedule, Mondays 05:17 UTC:

- **Monday** because Linus cuts releases on Sunday, so the newest stable is
  freshly available.
- **05:17, not 05:00** because scheduled runs cluster on the hour and get
  delayed there.

The whole matrix runs rather than just `build-mainline`: the runner images,
distro headers and pinned lint tools all drift between runs too, and a "CI"
run meaning the same thing regardless of trigger is less surprising than a
trigger-dependent subset.

**Failure criteria are unchanged** — longterm stays a hard gate, newest-stable
stays an informational warning. The schedule adds a time dimension, not a new
way to go red.

## Job summary

`build-mainline` now records the version it resolved on success too, not only
on failure:

```
✅ **`longterm`** — builds against Linux `6.12.51`
```

A green tick alone does not say which kernel was tested, which is the first
question a scheduled run raises.

## Verification

YAML parses, the cron expression resolves to Monday 05:17 UTC, and the bash of
every `run:` block in the workflow passes `bash -n` (with GitHub expressions
stubbed). shellcheck, ruff and the offline test class are clean.

Both READMEs now state the schedule and which channel is a gate.

Note that the first scheduled run will not fire until next Monday; the push
and PR triggers are unaffected and green here.
