### PR TITLE
docs: mark 0bda:8832 as Tested (reported)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ changes in this file.
   scheduled runs cluster and get delayed at `:00`.
 
 ### Changed
+- **`0bda:8832` (Realtek RTL8832AU reference board) moves from
+  Recognised to Tested (reported)** in the supported-devices table.
+  The reporter in
+  [#43](https://github.com/WimLee115/rtl8852au-build/issues/43) ran the
+  full suite on a DKMS install under kernel `7.0.12+kali-amd64` — 30
+  tests, 27 passed, 0 failed — and confirmed association and monitor
+  mode on the device. The status carries a *(reported)* suffix, and the
+  legend in both READMEs and on the landing page now says what that
+  means: the verification comes from the person who filed the hardware
+  request, with the evidence in their issue, rather than from the
+  maintainer on hardware in hand. Without that distinction *Tested*
+  would quietly claim more than the project can vouch for.
 - **`build-mainline` now records the kernel it resolved** in the job summary,
   on success as well as failure. A bare green tick did not say which version
   was actually tested, which is precisely the question a scheduled run raises.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -25,6 +25,8 @@ is generated automatically from commit history.
   on kernel 7.0.12, which surfaced two test-suite bugs: the module path was
   hard-coded to an in-tree build, and adapters behind a USB hub read as
   unbound ([issue #43](https://github.com/WimLee115/rtl8852au-build/issues/43)).
+  Re-ran the suite after the fix and confirmed association and monitor mode,
+  which is what moved that ID to *Tested (reported)*.
 
 ## Acknowledgements
 

--- a/CONTRIBUTORS.nl.md
+++ b/CONTRIBUTORS.nl.md
@@ -26,6 +26,8 @@ wordt automatisch gegenereerd uit de commit-historie.
   het modulepad was hardgecodeerd op een in-tree build, en adapters achter
   een USB-hub golden als niet-gebonden
   ([issue #43](https://github.com/WimLee115/rtl8852au-build/issues/43)).
+  Draaide de suite na de fix opnieuw en bevestigde associatie en monitor
+  mode, waarmee die ID op *Getest (melder)* kwam.
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -141,28 +141,31 @@ sudo ./dkms-remove.sh
 USB adapters based on the **RTL8852AU** or **RTL8832AU** chipset. The
 table below is generated from `os_dep/linux/usb_intf.c`.
 
-| USB ID       | Device                         | Chipset    | Status     |
-|--------------|--------------------------------|------------|------------|
-| `0bda:8832`  | Realtek reference board        | RTL8832AU  | Recognised |
-| `0bda:885a`  | Realtek reference board        | RTL8852AU  | Recognised |
-| `0bda:885c`  | Realtek reference board        | RTL8852AU  | Recognised |
-| `0b05:1997`  | ASUS USB-AX56 (variant)        | RTL8852AU  | Recognised |
-| `0b05:1a62`  | ASUS USB-AX56 (no cradle)      | RTL8832AU  | Recognised |
-| `0411:0312`  | Buffalo WI-U3-1200AX2(/N)      | RTL8852AU  | Recognised |
-| `2001:0141`  | D-Link DWA-X1850               | RTL8852AU  | Recognised |
-| `2001:3321`  | D-Link DWA-X1850 (variant)     | RTL8852AU  | Recognised |
-| `2001:332c`  | D-Link DWA-1850                | RTL8832AU  | Recognised |
-| `35bc:0100`  | TP-Link AX1800 (generic)       | RTL8852AU  | Recognised |
-| `2357:013f`  | TP-Link Archer TX20U Plus      | RTL8852AU  | **Tested** |
-| `2357:0140`  | TP-Link AX1800 (variant)       | RTL8852AU  | Recognised |
-| `2357:0141`  | TP-Link AX1800 (variant)       | RTL8852AU  | Recognised |
-| `3625:010f`  | TP-Link Archer TX35U Plus      | RTL8852AU  | Recognised |
-| `056e:4020`  | Elecom WDC-X1201DU3            | RTL8852AU  | Recognised |
+| USB ID       | Device                         | Chipset    | Status                |
+|--------------|--------------------------------|------------|-----------------------|
+| `0bda:8832`  | Realtek reference board        | RTL8832AU  | **Tested** (reported) |
+| `0bda:885a`  | Realtek reference board        | RTL8852AU  | Recognised            |
+| `0bda:885c`  | Realtek reference board        | RTL8852AU  | Recognised            |
+| `0b05:1997`  | ASUS USB-AX56 (variant)        | RTL8852AU  | Recognised            |
+| `0b05:1a62`  | ASUS USB-AX56 (no cradle)      | RTL8832AU  | Recognised            |
+| `0411:0312`  | Buffalo WI-U3-1200AX2(/N)      | RTL8852AU  | Recognised            |
+| `2001:0141`  | D-Link DWA-X1850               | RTL8852AU  | Recognised            |
+| `2001:3321`  | D-Link DWA-X1850 (variant)     | RTL8852AU  | Recognised            |
+| `2001:332c`  | D-Link DWA-1850                | RTL8832AU  | Recognised            |
+| `35bc:0100`  | TP-Link AX1800 (generic)       | RTL8852AU  | Recognised            |
+| `2357:013f`  | TP-Link Archer TX20U Plus      | RTL8852AU  | **Tested**            |
+| `2357:0140`  | TP-Link AX1800 (variant)       | RTL8852AU  | Recognised            |
+| `2357:0141`  | TP-Link AX1800 (variant)       | RTL8852AU  | Recognised            |
+| `3625:010f`  | TP-Link Archer TX35U Plus      | RTL8852AU  | Recognised            |
+| `056e:4020`  | Elecom WDC-X1201DU3            | RTL8852AU  | Recognised            |
 
-**Tested** means the maintainer has verified bind, association and
-traffic on that specific device. **Recognised** means the USB ID is in
-the driver and the chipset matches, but a full end-to-end check is
-pending.
+**Tested** means bind, association and traffic have been verified on
+that specific device. A *(reported)* suffix marks a device verified by
+the person who filed the hardware request rather than by the maintainer
+— for `0bda:8832` that evidence is the full test-suite run posted in
+[#43](https://github.com/WimLee115/rtl8852au-build/issues/43).
+**Recognised** means the USB ID is in the driver and the chipset
+matches, but a full end-to-end check is pending.
 
 To request a new ID, open a [hardware support
 request](https://github.com/WimLee115/rtl8852au-build/issues/new?template=hardware_support.yml)

--- a/README.nl.md
+++ b/README.nl.md
@@ -148,26 +148,30 @@ USB-adapters gebaseerd op de **RTL8852AU**- of
 **RTL8832AU**-chipset. De onderstaande tabel wordt gegenereerd uit
 `os_dep/linux/usb_intf.c`.
 
-| USB-ID       | Apparaat                       | Chipset    | Status     |
-|--------------|--------------------------------|------------|------------|
-| `0bda:8832`  | Realtek-referentiebord         | RTL8832AU  | Herkend    |
-| `0bda:885a`  | Realtek-referentiebord         | RTL8852AU  | Herkend    |
-| `0bda:885c`  | Realtek-referentiebord         | RTL8852AU  | Herkend    |
-| `0b05:1997`  | ASUS USB-AX56 (variant)        | RTL8852AU  | Herkend    |
-| `0b05:1a62`  | ASUS USB-AX56 (zonder dock)    | RTL8832AU  | Herkend    |
-| `0411:0312`  | Buffalo WI-U3-1200AX2(/N)      | RTL8852AU  | Herkend    |
-| `2001:0141`  | D-Link DWA-X1850               | RTL8852AU  | Herkend    |
-| `2001:3321`  | D-Link DWA-X1850 (variant)     | RTL8852AU  | Herkend    |
-| `2001:332c`  | D-Link DWA-1850                | RTL8832AU  | Herkend    |
-| `35bc:0100`  | TP-Link AX1800 (generiek)      | RTL8852AU  | Herkend    |
-| `2357:013f`  | TP-Link Archer TX20U Plus      | RTL8852AU  | **Getest** |
-| `2357:0140`  | TP-Link AX1800 (variant)       | RTL8852AU  | Herkend    |
-| `2357:0141`  | TP-Link AX1800 (variant)       | RTL8852AU  | Herkend    |
-| `3625:010f`  | TP-Link Archer TX35U Plus      | RTL8852AU  | Herkend    |
-| `056e:4020`  | Elecom WDC-X1201DU3            | RTL8852AU  | Herkend    |
+| USB-ID       | Apparaat                       | Chipset    | Status              |
+|--------------|--------------------------------|------------|---------------------|
+| `0bda:8832`  | Realtek-referentiebord         | RTL8832AU  | **Getest** (melder) |
+| `0bda:885a`  | Realtek-referentiebord         | RTL8852AU  | Herkend             |
+| `0bda:885c`  | Realtek-referentiebord         | RTL8852AU  | Herkend             |
+| `0b05:1997`  | ASUS USB-AX56 (variant)        | RTL8852AU  | Herkend             |
+| `0b05:1a62`  | ASUS USB-AX56 (zonder dock)    | RTL8832AU  | Herkend             |
+| `0411:0312`  | Buffalo WI-U3-1200AX2(/N)      | RTL8852AU  | Herkend             |
+| `2001:0141`  | D-Link DWA-X1850               | RTL8852AU  | Herkend             |
+| `2001:3321`  | D-Link DWA-X1850 (variant)     | RTL8852AU  | Herkend             |
+| `2001:332c`  | D-Link DWA-1850                | RTL8832AU  | Herkend             |
+| `35bc:0100`  | TP-Link AX1800 (generiek)      | RTL8852AU  | Herkend             |
+| `2357:013f`  | TP-Link Archer TX20U Plus      | RTL8852AU  | **Getest**          |
+| `2357:0140`  | TP-Link AX1800 (variant)       | RTL8852AU  | Herkend             |
+| `2357:0141`  | TP-Link AX1800 (variant)       | RTL8852AU  | Herkend             |
+| `3625:010f`  | TP-Link Archer TX35U Plus      | RTL8852AU  | Herkend             |
+| `056e:4020`  | Elecom WDC-X1201DU3            | RTL8852AU  | Herkend             |
 
-**Getest** betekent dat de maintainer op die specifieke adapter de
-binding, associatie en daadwerkelijk verkeer heeft geverifieerd.
+**Getest** betekent dat op die specifieke adapter de binding, associatie
+en daadwerkelijk verkeer zijn geverifieerd. Het achtervoegsel *(melder)*
+geeft aan dat die verificatie van de indiener van het hardwareverzoek
+komt en niet van de maintainer — voor `0bda:8832` is dat bewijs de
+volledige testsuite-run in
+[#43](https://github.com/WimLee115/rtl8852au-build/issues/43).
 **Herkend** betekent dat de USB-ID in de driver staat en de chipset
 klopt, maar dat een volledige end-to-end-check nog openstaat.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -438,7 +438,7 @@
         <tbody>
           <tr><td class="id">2357:013f</td><td>TP-Link Archer TX20U Plus</td><td>RTL8852AU</td><td><span class="pill tested">Tested</span></td></tr>
           <tr><td class="id">3625:010f</td><td>TP-Link Archer TX35U Plus</td><td>RTL8852AU</td><td><span class="pill reco">Recognised</span></td></tr>
-          <tr><td class="id">0bda:8832</td><td>Realtek reference board</td><td>RTL8832AU</td><td><span class="pill reco">Recognised</span></td></tr>
+          <tr><td class="id">0bda:8832</td><td>Realtek reference board</td><td>RTL8832AU</td><td><span class="pill tested" title="Verified by the reporter in issue #43, not by the maintainer">Tested · reported</span></td></tr>
           <tr><td class="id">0bda:885a</td><td>Realtek reference board</td><td>RTL8852AU</td><td><span class="pill reco">Recognised</span></td></tr>
           <tr><td class="id">0bda:885c</td><td>Realtek reference board</td><td>RTL8852AU</td><td><span class="pill reco">Recognised</span></td></tr>
           <tr><td class="id">0b05:1997</td><td>ASUS USB-AX56 (variant)</td><td>RTL8852AU</td><td><span class="pill reco">Recognised</span></td></tr>
@@ -454,7 +454,7 @@
         </tbody>
       </table>
     </div>
-    <p class="note"><b>Tested</b> = maintainer verified bind, association and traffic on that device. <i>Recognised</i> = the USB ID is in the driver and the chipset matches, but a full end-to-end check is pending. Have one of the Recognised adapters working? <a href="https://github.com/WimLee115/rtl8852au-build/issues/new?template=hardware_support.yml">Send an <code>lsusb -v</code> report</a> and it moves to Tested.</p>
+    <p class="note"><b>Tested</b> = bind, association and traffic verified on that device. <b>Tested · reported</b> means that verification came from the person who filed the hardware request rather than from the maintainer — for <code>0bda:8832</code> the evidence is the full test-suite run in <a href="https://github.com/WimLee115/rtl8852au-build/issues/43">#43</a>. <i>Recognised</i> = the USB ID is in the driver and the chipset matches, but a full end-to-end check is pending. Have one of the Recognised adapters working? <a href="https://github.com/WimLee115/rtl8852au-build/issues/new?template=hardware_support.yml">Send an <code>lsusb -v</code> report</a> and it moves to Tested.</p>
   </div>
 </section>
 


### PR DESCRIPTION
Follow-up to #43 and #44.

## What changed

`0bda:8832` (Realtek RTL8832AU reference board) moves from **Recognised** to **Tested (reported)** in the supported-devices table — README, README.nl, and the landing page.

## Why

After the test-suite fixes in #44 landed, the reporter re-ran the suite on their adapter:

```
Ran 30 tests in 11.901s
OK (skipped=3)
Total: 30 | Passed: 27 | Failed: 0 | Errors: 0 | Skipped: 3
```

Zero failures on a DKMS install under kernel `7.0.12+kali-amd64`, including `test_01_device_bound` and the three module-path tests that previously failed. Their original report also ticked *"Yes — connection works"* and states that connection and monitor mode both work. Bind, association and traffic are therefore all accounted for.

## Why not a plain *Tested*

Every other **Tested** entry in that table means the maintainer verified the device with the hardware in hand. This one rests on a third party's issue thread. Collapsing the two would overstate what the project can vouch for, so:

- the status carries a `(reported)` suffix — `Tested · reported` on the landing page;
- the legend in all three places now says what that means and links to [#43](https://github.com/WimLee115/rtl8852au-build/issues/43), where the evidence lives.

## Also

- `CHANGELOG.md` — entry under `[Unreleased] → Changed`.
- `CONTRIBUTORS.md` / `.nl.md` — Omelug's credit now records the post-fix re-run, since that is what the new status rests on.

Docs only; no driver or test code touched.