### PR TITLE
ci: give every job an explicit timeout-minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
   build:
     name: Build (${{ matrix.os }}, kernel ${{ matrix.kver }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -96,6 +97,7 @@ jobs:
   build-mainline:
     name: Build (mainline ${{ matrix.channel }})
     runs-on: ubuntu-24.04
+    timeout-minutes: 25
     # The newest stable often outpaces what an out-of-tree vendor driver
     # supports (e.g. kernel 7.1 refactored many cfg80211_ops callbacks from
     # net_device to wireless_dev). The build step treats a stable-channel
@@ -194,6 +196,7 @@ jobs:
   dkms:
     name: DKMS scripts dry-run
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
     needs: build
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -226,6 +229,7 @@ jobs:
   python:
     name: Python lint and offline tests
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,6 +32,7 @@ jobs:
   build:
     name: Build Pages artifact
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -55,6 +56,7 @@ jobs:
     name: Deploy to GitHub Pages
     needs: build
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ changes in this file.
 ## [Unreleased]
 
 ### Added
+- **Every CI job now carries an explicit `timeout-minutes`** — 20 for the
+  distro build matrix, 25 for `build-mainline`, 20 for the DKMS dry-run,
+  and 10 for the Python job and both Pages jobs. GitHub's default is six
+  hours, and a run on `main` showed what that costs: `Install build
+  dependencies` sat for 22 minutes on an `apt-get update` retrying an
+  unreachable `azure.archive.ubuntu.com` mirror, against a normal job time
+  of under two minutes. Weekly scheduled runs make that worse — nobody is
+  watching a Monday-morning build, so a hung job would hold a runner slot
+  most of the day before the default fired. Each limit is roughly ten times
+  the observed runtime, so ordinary mirror slowness still passes.
 - **CI runs weekly on a schedule** (Mondays, 05:17 UTC) in addition to push
   and pull-request triggers. The `build-mainline` job resolves the newest
   kernel.org stable and longterm releases at run time, so what it tests moves


### PR DESCRIPTION
GitHub's default job timeout is six hours. A run on main showed what that costs in practice: Build (mainline longterm) sat for 22 minutes in "Install build dependencies", where apt-get update kept retrying an unreachable azure.archive.ubuntu.com mirror before falling back to archive.ubuntu.com. The same job takes under two minutes normally, and nothing would have stopped it short of the six-hour default.

Since the matrix also runs weekly on a schedule, a hung job now happens where nobody is looking — it would hold a runner slot most of the day before timing out on its own.

Limits are roughly ten times each job's observed runtime, so a slow but working mirror still passes; only a genuine hang is cut short.

<!--
  Thanks for taking the time to send a PR.

  Bedankt voor je tijd om een PR in te dienen.

  Please fill in what is relevant; remove sections that don't apply.
  Vul in wat relevant is; verwijder secties die niet van toepassing zijn.
-->

## What this changes / Wat dit wijzigt

<!--
  One short paragraph. What problem does this solve, or which feature does
  it add? Link to the issue if there is one.

  Eén korte paragraaf. Welk probleem lost dit op, of welke feature voegt
  dit toe? Link naar het issue indien aanwezig.
-->

Closes #_____

## Type of change / Type wijziging

- [ ] Bug fix (kernel compatibility, monitor-mode race, etc.) / Bugfix
- [ ] Hardware support (new USB ID) / Hardware-ondersteuning (nieuwe USB-ID)
- [ ] New feature (dashboard, tests, tools) / Nieuwe functionaliteit
- [ ] Documentation only / Alleen documentatie
- [ ] Build / CI / packaging / Build / CI / packaging
- [ ] Refactor / chore (no functional change) / Refactor / chore

## Driver-source patches only / Alleen voor driver-source-patches

<!-- Skip this section if you're not touching core/, hal/, phl/, os_dep/. -->
<!-- Sla deze sectie over als je core/, hal/, phl/, os_dep/ niet aanraakt. -->

- [ ] Patch follows the Realtek vendor style (tabs, K&R braces, no large reformats)
      / Volgt de Realtek vendor-stijl (tabs, K&R braces, geen grote herformatteringen)
- [ ] Each commit message explains *why*, not just *what*
      / Elke commit-message legt het *waarom* uit, niet alleen het *wat*
- [ ] LINUX_VERSION_CODE guarded where appropriate
      / `LINUX_VERSION_CODE`-guards toegepast waar nodig

## Hardware additions only / Alleen voor hardware-toevoegingen

- [ ] `lsusb -v -d VVVV:PPPP` output attached / `lsusb -v`-output toegevoegd
- [ ] Confirmed RTL8852AU or RTL8832AU chipset (datasheet / FCC-ID lookup)
      / Bevestigd dat het een RTL8852AU- of RTL8832AU-chipset is
- [ ] Driver loads + interface appears on this device
      / Driver laadt en de interface verschijnt op dit apparaat

## How was this tested / Hoe is dit getest

<!--
  - Kernel version(s) you compiled against: e.g. 6.19.14+kali-amd64
  - Did `sudo ./tests/run_tests.sh` pass?
  - Anything destructive (rmmod, rapid toggle)? Did it stay stable?

  - Tegen welke kernel-versie(s) gecompileerd: bijv. 6.19.14+kali-amd64
  - Slaagde `sudo ./tests/run_tests.sh`?
  - Iets destructiefs (rmmod, rapide toggle)? Bleef het stabiel?
-->

## Checklist

- [ ] CI is green on this branch / CI is groen op deze branch
- [ ] `ruff check` passes on Python changes / `ruff check` slaagt voor Python-wijzigingen
- [ ] `shellcheck` passes on shell changes / `shellcheck` slaagt voor shell-wijzigingen
- [ ] CHANGELOG.md updated under `## [Unreleased]`
      / CHANGELOG.md bijgewerkt onder `## [Unreleased]`
- [ ] Docs updated where the behaviour changes (README, docs/dashboard.md, …)
      / Docs bijgewerkt waar gedrag verandert
