### PR TITLE
ci: stop a stalled mirror from hanging apt and curl

### DIFF
--- a/.github/scripts/apt-install.sh
+++ b/.github/scripts/apt-install.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+#
+# Hardened apt-get for CI: update + install, with timeouts and retries.
+#
+# Why this exists: the hosted runners resolve archives through a mirrorlist.
+# When the Azure mirror is unreachable, apt falls back to archive.ubuntu.com --
+# and a connection there can stall with the response headers already received
+# and the body never arriving. apt applies no transfer timeout by default, so
+# it waits forever. Retries alone do not help either: a stall is not an error,
+# so apt never retries it.
+#
+# On 2026-08-18 that cost four jobs 20-25 idle minutes each (runs 32156628064,
+# 32160272125, 32161189076). The last line in every one of those logs is an
+# ordinary-looking `Get:5 ... -security InRelease`.
+#
+# Three layers of defence, cheapest first:
+#   1. Acquire::*::Timeout turns a stalled socket into an ordinary failure,
+#      which Acquire::Retries then retries internally without leaving the run.
+#   2. DPkg::Lock::Timeout rides out unattended-upgrades still holding the dpkg
+#      lock on a freshly booted runner, instead of failing on the spot.
+#   3. The outer `timeout` plus retry loop is the backstop for what those two
+#      miss: a mirror that is slow rather than dead, or a hang inside dpkg.
+#
+# The whole thing is bounded by one shared budget, because a job killed by
+# `timeout-minutes` reports `cancelled` -- which sends no failure notification
+# and reads like someone pressed Cancel. Failing the step inside the budget
+# turns the same stall into a real red X that names apt.
+#
+# Usage: .github/scripts/apt-install.sh <package>...
+#
+# SPDX-License-Identifier: GPL-2.0
+
+set -euo pipefail
+
+if [[ $# -eq 0 ]]; then
+    echo "usage: $0 <package>..." >&2
+    exit 2
+fi
+
+# Budget for this script as a whole. Sized to fail loudly well inside the
+# tightest apt-using job timeout (20 minutes) with room to spare for the build
+# that follows.
+TOTAL_BUDGET="${APT_TOTAL_BUDGET:-600}"
+
+# Per-attempt ceilings. Healthy runs finish update+install in 9-135s, so these
+# leave several times the observed worst case before anything is killed.
+UPDATE_TIMEOUT="${APT_UPDATE_TIMEOUT:-120}"
+INSTALL_TIMEOUT="${APT_INSTALL_TIMEOUT:-300}"
+
+ATTEMPTS="${APT_ATTEMPTS:-3}"
+
+export DEBIAN_FRONTEND=noninteractive
+
+# $1 is the wall-clock ceiling for this attempt; the rest is the apt-get
+# command line.
+apt_get() {
+    local cap="$1"
+    shift
+
+    sudo timeout --signal=INT --kill-after=30s "$cap" \
+        apt-get \
+        -o Acquire::Retries=3 \
+        -o Acquire::http::Timeout=20 \
+        -o Acquire::https::Timeout=20 \
+        -o DPkg::Lock::Timeout=60 \
+        "$@"
+}
+
+# Runs one apt-get sub-command with retries: retry_apt_get <sub-command>
+# <per-attempt timeout> [extra args...]
+retry_apt_get() {
+    local action="$1"
+    local cap="$2"
+    shift 2
+
+    local attempt rc left this_cap
+
+    for ((attempt = 1; attempt <= ATTEMPTS; attempt++)); do
+        left=$((TOTAL_BUDGET - SECONDS))
+        if [[ $left -lt 30 ]]; then
+            echo "::error::apt-get $action exhausted the ${TOTAL_BUDGET}s budget for installing packages"
+            return 124
+        fi
+
+        # Never let one attempt overrun what is left of the shared budget.
+        this_cap=$cap
+        if [[ $this_cap -gt $left ]]; then
+            this_cap=$left
+        fi
+
+        rc=0
+        apt_get "$this_cap" "$action" "$@" || rc=$?
+
+        if [[ $rc -eq 0 ]]; then
+            return 0
+        fi
+
+        if [[ $attempt -eq $ATTEMPTS ]]; then
+            echo "::error::apt-get $action failed after $ATTEMPTS attempts (exit $rc)"
+            return "$rc"
+        fi
+
+        # 124 is `timeout` reporting that it had to kill apt: the stall case.
+        if [[ $rc -eq 124 ]]; then
+            echo "::warning::apt-get $action stalled and was killed after ${this_cap}s (attempt $attempt/$ATTEMPTS); retrying"
+        else
+            echo "::warning::apt-get $action failed with exit $rc (attempt $attempt/$ATTEMPTS); retrying"
+        fi
+
+        sleep $((attempt * 10))
+    done
+}
+
+retry_apt_get update "$UPDATE_TIMEOUT"
+retry_apt_get install "$INSTALL_TIMEOUT" -y "$@"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,11 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Install build dependencies
+        # Via the hardened wrapper: a stalled mirror used to hang apt for the
+        # job's entire timeout budget without emitting a single error. The
+        # script header has the details.
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
+          .github/scripts/apt-install.sh \
             build-essential \
             dkms \
             xz-utils \
@@ -115,14 +117,20 @@ jobs:
 
       - name: Install build dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
+          .github/scripts/apt-install.sh \
             build-essential bc bison flex libssl-dev libelf-dev xz-utils jq curl
 
       - name: Resolve ${{ matrix.channel }} kernel version
         id: kver
         run: |
-          curl -fsSL https://www.kernel.org/releases.json -o releases.json
+          # --speed-limit/--speed-time abort a transfer that has gone quiet
+          # rather than one that is merely slow, which is the failure mode that
+          # matters here: a connection that stays open and stops sending. A
+          # bare curl waits on that indefinitely, exactly as apt used to.
+          curl --retry 3 --retry-delay 5 --retry-all-errors \
+            --connect-timeout 15 --max-time 60 \
+            --speed-limit 1000 --speed-time 30 \
+            -fsSL https://www.kernel.org/releases.json -o releases.json
           if [ "${{ matrix.channel }}" = "stable" ]; then
             ver="$(jq -r '.latest_stable.version' releases.json)"
           else
@@ -139,7 +147,12 @@ jobs:
         run: |
           ver="${{ steps.kver.outputs.ver }}"
           major="${{ steps.kver.outputs.major }}"
-          curl -fsSL "https://cdn.kernel.org/pub/linux/kernel/v${major}.x/linux-${ver}.tar.xz" -o linux.tar.xz
+          # ~150 MB, so --max-time is generous; --speed-time is what actually
+          # catches a stall, well before the job timeout does.
+          curl --retry 3 --retry-delay 5 --retry-all-errors \
+            --connect-timeout 15 --max-time 900 \
+            --speed-limit 10000 --speed-time 60 \
+            -fsSL "https://cdn.kernel.org/pub/linux/kernel/v${major}.x/linux-${ver}.tar.xz" -o linux.tar.xz
           tar xf linux.tar.xz
           make -C "linux-${ver}" defconfig
           # The vendored Realtek tree carries many benign code-style warnings
@@ -202,12 +215,13 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - name: Install deps
         run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential dkms xz-utils "linux-headers-$(uname -r)" shellcheck
+          .github/scripts/apt-install.sh \
+            build-essential dkms xz-utils "linux-headers-$(uname -r)" shellcheck
 
       - name: Lint shell scripts
         run: |
-          shellcheck dkms-install.sh dkms-remove.sh tests/run_tests.sh
+          shellcheck dkms-install.sh dkms-remove.sh tests/run_tests.sh \
+            .github/scripts/apt-install.sh
 
       - name: Install via DKMS
         run: sudo ./dkms-install.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,31 @@ changes in this file.
   on success as well as failure. A bare green tick did not say which version
   was actually tested, which is precisely the question a scheduled run raises.
 
+### Fixed
+- **CI no longer hangs on a stalled Ubuntu mirror.** The runners resolve
+  archives through a mirrorlist; when the Azure mirror is unreachable, apt
+  falls back to `archive.ubuntu.com`, where a connection can stall with the
+  response headers received and the body never arriving. apt applies no
+  transfer timeout by default, and retries do not help because a stall is not
+  an error — so it waits forever. On 2026-08-18 that cost four jobs 20-25
+  idle minutes each, in three separate runs, always on the same
+  `<suite>-security InRelease` fetch; jobs that reached the Azure mirror in
+  those same runs finished in about two minutes. Package installation now
+  goes through `.github/scripts/apt-install.sh`, which sets
+  `Acquire::http/https::Timeout` (turning a stall into a retryable failure),
+  `Acquire::Retries`, and `DPkg::Lock::Timeout` for a runner where
+  unattended-upgrades still holds the dpkg lock, with `timeout(1)` plus a
+  shared 600-second budget as the backstop. That budget matters beyond speed:
+  a job killed by `timeout-minutes` reports `cancelled`, for which GitHub
+  sends no failure notification, so a stall on the weekly schedule would have
+  passed silently — a failing *step* is a real red X that names apt.
+- **The two `curl` downloads in `build-mainline` carry the same protection.**
+  `kernel.org/releases.json` and the ~150 MB kernel tarball ran without a
+  connect timeout, retry or stall detection, which is the same failure class
+  in the job with the largest transfers. Both now use `--retry` with
+  `--speed-limit`/`--speed-time`, which aborts a transfer that has gone quiet
+  rather than one that is merely slow.
+
 ## [1.16.1] — 2026-08-18
 
 A maintenance release on top of `1.16.0`: one monitor-mode kernel panic, three


### PR DESCRIPTION
## What this changes / Wat dit wijzigt

CI kept losing whole jobs to a stalled Ubuntu mirror. The runners resolve
archives through a mirrorlist; when the Azure mirror is unreachable, apt falls
back to `archive.ubuntu.com`, where a connection can stall with the response
headers already received and the body never arriving. apt applies no transfer
timeout by default, and its own retries do not help — a stall is not an error,
so it never retries. It simply waits.

On 2026-08-18 that cost four jobs 20-25 idle minutes each across three runs
([32156628064](https://github.com/WimLee115/rtl8852au-build/actions/runs/32156628064),
[32160272125](https://github.com/WimLee115/rtl8852au-build/actions/runs/32160272125),
[32161189076](https://github.com/WimLee115/rtl8852au-build/actions/runs/32161189076)),
every one of them stopping on the same `<suite>-security InRelease` fetch —
while jobs that reached the Azure mirror in those same runs finished in about
two minutes. Re-running 32161189076 with no code change went green on all six
jobs, which is what makes this infrastructure rather than a build problem.

The oldest instance predates #48 by half an hour (job 95775297875 on `dd08308`
sat 1916s in `Install build dependencies`, with no `timeout-minutes` anywhere
in the workflow at that commit), so this is not a regression from that change —
it is the thing that change started bounding.

**Why a budget, and not just a bigger timeout:** a job killed by
`timeout-minutes` reports `cancelled`, and GitHub sends no failure notification
for a cancelled run. A stall on the Monday schedule would have gone out as
silence — precisely defeating the weekly LTS signal that schedule exists for.
The wrapper fails the *step* inside the budget instead, which is a real red X
that names apt.

### What is in here

- **New `.github/scripts/apt-install.sh`**, used by all three package-install
  steps (`build`, `build-mainline`, `dkms`):
  - `Acquire::http/https::Timeout=20` — turns a stalled socket into an ordinary
    failure, which is what makes retries meaningful at all;
  - `Acquire::Retries=3` — retries it inside apt, without leaving the run;
  - `DPkg::Lock::Timeout=60` — rides out `unattended-upgrades` still holding the
    dpkg lock on a freshly booted runner;
  - `timeout(1)` per attempt (120s update / 300s install) under a shared
    600-second budget, with each attempt clamped to what is left of it.
    Healthy runs do update+install in 9-135s, so this leaves several times the
    observed worst case; the budget keeps even a total outage failing loudly
    well inside the 20-minute job limit.
- **The two `curl` downloads in `build-mainline`** (`releases.json` and the
  ~150 MB kernel tarball) had the same exposure — no connect timeout, no retry,
  no stall detection — in the job that moves the most data. They now use
  `--retry` with `--speed-limit`/`--speed-time`, which aborts a transfer that
  has gone *quiet* rather than one that is merely slow.
- The new script is added to the existing `shellcheck` lint list.

`timeout-minutes` values are deliberately left alone: at 5-12x observed runtime
they are a backstop, not the defect.

## Type of change / Type wijziging

- [x] Build / CI / packaging / Build / CI / packaging

## How was this tested / Hoe is dit getest

- `shellcheck` 0.11.0 over the exact CI lint list including the new script: clean.
- The workflow parses as YAML with all four jobs intact; no bare `apt-get` or
  unprotected `curl` remains in `ci.yml`.
- Retry logic exercised against a stubbed `apt-get` covering seven paths: happy
  path; transient failure recovering on attempt 2; hard failure exhausting all
  three attempts (exit 100); a real hang killed by `timeout` (exit 124, stall
  warning emitted); budget exhaustion; a 600s per-attempt cap correctly clamped
  down to the 31s left in the budget; and no-arguments usage (exit 2).
- curl flags verified live: the exact flag set fetches `releases.json`
  (`latest_stable: 7.2`), and `--speed-limit`/`--speed-time` aborts a
  deliberately slow transfer with exit 28 and is retried by `--retry-all-errors`.
- No driver source touched, so no hardware run applies.

## Checklist

- [x] `shellcheck` passes on shell changes / `shellcheck` slaagt voor shell-wijzigingen
- [x] CHANGELOG.md updated under `## [Unreleased]` / CHANGELOG.md bijgewerkt
- [ ] CI is green on this branch / CI is groen op deze branch — to be confirmed by this PR's own run
