### PR TITLE
ci: fail the step, not the job, when a build or a mirror goes wrong

### DIFF
--- a/.github/scripts/apt-install.sh
+++ b/.github/scripts/apt-install.sh
@@ -37,9 +37,11 @@ if [[ $# -eq 0 ]]; then
     exit 2
 fi
 
-# Budget for this script as a whole. Sized to fail loudly well inside the
-# tightest apt-using job timeout (20 minutes) with room to spare for the build
-# that follows.
+# Budget for this script as a whole. The effective ceiling is 650s rather than
+# 600: the last attempt is clamped to whatever is left of the budget, and then
+# adds the 30s `timeout --kill-after` grace and the 20s second backoff on top.
+# Sized to fail loudly well inside the tightest apt-using job timeout (20
+# minutes) with room to spare for the build that follows.
 TOTAL_BUDGET="${APT_TOTAL_BUDGET:-600}"
 
 # Per-attempt ceilings. Healthy runs finish update+install in 9-135s, so these

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,13 +64,30 @@ jobs:
           sha256sum -c CHECKSUMS.sha256
 
       - name: Build module
+        # Without pipefail the pipeline reports tee's status, not make's, so a
+        # broken build is caught only by the `test -f` below -- and that misses
+        # every failure that still leaves a module on disk. `all:` runs
+        # `firmware` and `modules` as independent goals, so under -j make can
+        # exit non-zero on the firmware step while modules links 8852au.ko
+        # anyway, and the step goes green on a build that failed. The mainline
+        # job below has always set this; the distro matrix was the one that did
+        # not.
         run: |
+          set -euo pipefail
           make -j"$(nproc)" 2>&1 | tee build.log
           test -f 8852au.ko
 
       - name: Module metadata
+        # sed rather than head, because head closes the pipe after 40 lines and
+        # modinfo has ~160 to write: the next write takes SIGPIPE. That is
+        # invisible today only because the pipeline reports head's status, and
+        # it turns into exit 141 on every run the moment anyone adds pipefail.
+        # sed reads to EOF, so the status is modinfo's -- worth having, since
+        # `modinfo` on a missing or unreadable module currently exits 0 and this
+        # step passes.
         run: |
-          modinfo ./8852au.ko | head -40
+          set -euo pipefail
+          modinfo ./8852au.ko | sed -n '1,40p'
 
       - name: Count warnings
         run: |
@@ -127,9 +144,14 @@ jobs:
           # rather than one that is merely slow, which is the failure mode that
           # matters here: a connection that stays open and stops sending. A
           # bare curl waits on that indefinitely, exactly as apt used to.
-          curl --retry 3 --retry-delay 5 --retry-all-errors \
-            --connect-timeout 15 --max-time 60 \
-            --speed-limit 1000 --speed-time 30 \
+          #
+          # --max-time bounds one attempt, not the sequence, so --retry
+          # multiplies it; --retry-max-time is what caps the whole thing. The
+          # ceiling here is 40s of retry window plus one final 20s attempt, for
+          # a 30 kB file that has never taken a second.
+          curl --retry 2 --retry-delay 5 --retry-all-errors --retry-max-time 40 \
+            --connect-timeout 15 --max-time 20 \
+            --speed-limit 1000 --speed-time 10 \
             -fsSL https://www.kernel.org/releases.json -o releases.json
           if [ "${{ matrix.channel }}" = "stable" ]; then
             ver="$(jq -r '.latest_stable.version' releases.json)"
@@ -147,11 +169,18 @@ jobs:
         run: |
           ver="${{ steps.kver.outputs.ver }}"
           major="${{ steps.kver.outputs.major }}"
-          # ~150 MB, so --max-time is generous; --speed-time is what actually
-          # catches a stall, well before the job timeout does.
-          curl --retry 3 --retry-delay 5 --retry-all-errors \
-            --connect-timeout 15 --max-time 900 \
-            --speed-limit 10000 --speed-time 60 \
+          # --max-time bounds one attempt, not the sequence: with --retry 3 the
+          # old 900s ceiling was really (3+1)*900 + 3*5 = 3615s, more than twice
+          # this job's own 25-minute limit. Overrunning that limit kills the job
+          # rather than the step, and a killed job reports `cancelled`, which
+          # sends no notification -- precisely the silence the weekly schedule
+          # exists to break. --retry-max-time caps the sequence at 240s of retry
+          # window plus one final 120s attempt. The CDN delivers this ~150 MB
+          # file in well under 15s, so 120s still admits a mirror running ten
+          # times slower than anything yet observed.
+          curl --retry 2 --retry-delay 5 --retry-all-errors --retry-max-time 240 \
+            --connect-timeout 15 --max-time 120 \
+            --speed-limit 10000 --speed-time 30 \
             -fsSL "https://cdn.kernel.org/pub/linux/kernel/v${major}.x/linux-${ver}.tar.xz" -o linux.tar.xz
           tar xf linux.tar.xz
           make -C "linux-${ver}" defconfig
@@ -206,11 +235,19 @@ jobs:
           fi
 
   # ── DKMS install/remove dry-run (validates the helper scripts) ─────────
+  #
+  # Deliberately not `needs: build`. Nothing here consumes what that job
+  # produces -- dkms-install.sh strips *.ko and *.o out of the tree it copies,
+  # and `dkms build` recompiles from source -- so the edge only ever ordered the
+  # two, and it put the repository's only shellcheck run behind an apt step on
+  # somebody else's runner. In run 32161189076 a stalled mirror killed the
+  # ubuntu-22.04 build at 16:56:45 and this job was skipped in the same second;
+  # a job skipped by an unmet `needs` reports success, so a required check went
+  # green having never run. Nothing that did not run should look like it passed.
   dkms:
     name: DKMS scripts dry-run
     runs-on: ubuntu-24.04
     timeout-minutes: 20
-    needs: build
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - name: Install deps
@@ -233,6 +270,11 @@ jobs:
         run: sudo ./dkms-remove.sh
 
       - name: Verify clean state
+        # Do not add pipefail to this step. `grep -q` exits on the first match,
+        # so `dkms status` takes SIGPIPE and the pipeline returns 141 rather
+        # than 0: the `if` goes false and the gate stops firing exactly when it
+        # has something to catch. Safe at today's one or two DKMS entries, but
+        # it fails open, not shut, once the runner image carries more.
         run: |
           if dkms status | grep -q rtl8852au; then
             echo "::error::DKMS entry still present after remove"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,14 @@ changes in this file.
 - **`build-mainline` now records the kernel it resolved** in the job summary,
   on success as well as failure. A bare green tick did not say which version
   was actually tested, which is precisely the question a scheduled run raises.
+- **The DKMS dry-run no longer waits on the build matrix.** It shares no
+  artefact with those jobs — `dkms-install.sh` strips `*.ko` and `*.o` out of
+  the tree it copies, and `dkms build` compiles from source — so `needs: build`
+  only ever ordered them. The cost was real: a job skipped because its `needs`
+  went unmet reports *success*, and `DKMS scripts dry-run` is a required check,
+  so a single stalled Ubuntu mirror in one build leg turned a required check
+  green without running it. It also gated the repository's only `shellcheck`
+  run behind an apt step on a different runner.
 
 ### Fixed
 - **CI no longer hangs on a stalled Ubuntu mirror.** The runners resolve
@@ -66,7 +74,23 @@ changes in this file.
   connect timeout, retry or stall detection, which is the same failure class
   in the job with the largest transfers. Both now use `--retry` with
   `--speed-limit`/`--speed-time`, which aborts a transfer that has gone quiet
-  rather than one that is merely slow.
+  rather than one that is merely slow, and `--retry-max-time` to bound the
+  retry sequence. That last part was the catch: `--max-time` applies to a
+  single attempt, so `--retry 3 --max-time 900` on the ~150 MB tarball was
+  really a 3615-second ceiling — over an hour, against a job limited to 25
+  minutes. The stall protection was real; the total was bounded by nothing
+  except the job timeout it was written to stay inside.
+- **A failed `make` no longer passes the build step.** `make | tee build.log`
+  reports tee's exit status, not make's, so the distro matrix relied entirely
+  on the `test -f 8852au.ko` that follows — and that only catches failures
+  which leave no module behind. `all:` builds `firmware` and `modules` as
+  independent goals with no ordering between them, so under `-j` make can fail
+  on the firmware step and still link `8852au.ko`, exiting non-zero into a
+  green tick. The step now sets `pipefail`, as the mainline job always has.
+  `Module metadata` had the same defect from the other direction: `modinfo` on
+  a missing or unreadable module exits 0 once piped into `head`, so that step
+  could never fail either. It reads through `sed` now, which does not close the
+  pipe early and therefore reports modinfo's real status.
 
 ## [1.16.1] — 2026-08-18
 


### PR DESCRIPTION
## What this changes / Wat dit wijzigt

[#48](https://github.com/WimLee115/rtl8852au-build/pull/48) and
[#49](https://github.com/WimLee115/rtl8852au-build/pull/49) both rest on one
assumption: that a stall or a broken build shows up as a **failing step**. That
matters because a job killed by `timeout-minutes` reports `cancelled`, and
GitHub sends no failure notification for a cancelled run — so the weekly Monday
cron, whose entire purpose is to email when a new LTS breaks the build, goes out
as silence. Three paths where that assumption does not hold were still open, and
one of them was shipped by #49 itself.

### 1. The retry window was unbounded (a live regression from #49)

`curl --max-time` bounds a **single attempt**, not the retry sequence, and
`--retry` multiplies it. Measured on curl 8.21.0 against a blackholed address:

| flags | expected | measured |
|---|---|---|
| `--retry 3 --retry-delay 5 --max-time 3` | `(3+1)×3 + 3×5 = 27s` | **27s** |
| same, plus `--retry-max-time 10` | bounded | **11s** |

So the kernel tarball fetch merged this afternoon carried a real ceiling of
`(3+1)×900 + 3×5 = 3615s` — just over an hour — inside a job limited to 25
minutes. `--retry-max-time` caps the sequence. The CDN delivers that ~150 MB
file in well under 15s (the whole *Fetch and prepare* step, including `tar xf`,
`defconfig`, `olddefconfig` and `modules_prepare`, runs 25-44s), so 120s per
attempt still admits a mirror ten times slower than anything yet observed.

One consequence worth naming: that curl sits in *Fetch and prepare*, which has
no stable-channel leniency, so a genuinely congested CDN would now turn
`Build (mainline stable)` red rather than hang it. Stable is not a required
check, and a red X beats a silent 60-minute hang, but it is a behaviour change.

### 2. Two steps that could not fail

`make -j"$(nproc)" 2>&1 | tee build.log` reports **tee's** exit status, so the
distro matrix leaned entirely on the `test -f 8852au.ko` that follows — which
only catches failures that leave no module behind. `all:` builds `firmware` and
`modules` as independent goals with no ordering edge, so under `-j` make can
fail on firmware and still link the module. Reproduced with a Makefile of that
shape under `bash -e`:

```
current  (no pipefail): rc=0   ← green, while make exited 2 and the .ko exists
new      (set -euo pipefail): rc=2
```

`modinfo ./8852au.ko | head -40` is the same defect from the other side. modinfo
writes 160 lines and `head` closes the pipe at 40, so modinfo takes SIGPIPE —
invisible only because the pipeline reports head's status. Adding `pipefail` to
that form would redden every run (**49 of 50** measured, exit 141); `sed -n
'1,40p'` reads to EOF, so **0 of 50**. It also fixes something real: `modinfo`
on a missing module currently exits 0, so that step could never fail.

### 3. A required check that went green without running

The DKMS dry-run consumes nothing the build matrix produces — `dkms-install.sh`
strips `*.ko` and `*.o` out of the tree it copies, and `dkms build` recompiles
from source — so `needs: build` only ordered them. A job skipped for an unmet
`needs` reports **success**, and this is a required check, so one stalled mirror
in one build leg turned a required check green without running it (run
32161189076: the ubuntu-22.04 build was killed at 16:56:45 and the dry-run was
skipped in the same second, even though the other build leg had passed).

It also put the repository's only `shellcheck` run behind an apt step on another
runner — so #49, whose entire content was a new shell script, had its own lint
gated behind the apt step it was fixing.

### What deliberately did not change

`timeout-minutes` stays at 20/25/20/10. With curl bounded, every job's
step-level ceiling now fires well before its job cap:

| job | cap | computed worst case | headroom |
|---|---|---|---|
| `build` | 20m | 650s apt + 151s compute = **13m21s** | 33% |
| `build-mainline` | 25m | 650 + 60 + 360 + 132 = **20m02s** | 20% |
| `dkms` | 20m | 650 apt + 164s compute = **13m34s** | 32% |
| `python` | 10m | 18s observed; no step-level bound, cap is the only backstop | — |

The caps are a backstop that should now never fire, and the outcome they produce
when they do is the silent one. Shrinking them trades that away for nothing on a
public repo with free minutes and a peak of six concurrent jobs.

### Two findings recorded but not shipped

- **`defaults: {run: {shell: bash}}` is not the shortcut here.** It applies
  `-eo pipefail` to every step, which would break `modinfo | head` on every run
  and silently disarm the `dkms status | grep -q` gate in *Verify clean state*
  (grep exits on first match → SIGPIPE → 141 → the `if` goes false exactly when
  it has something to catch). The fix has to be per-step; there is now a comment
  at that step saying so.
- **A ref-based `concurrency` group key silently cancels *pending* runs**, and
  `cancel-in-progress` does not protect against it. Noted for whenever
  concurrency is actually wanted; measured benefit here across 114 runs was zero.

## Type of change / Type wijziging

- [x] Build / CI / packaging

## How was this tested / Hoe is dit getest

All measured locally; no CI was triggered to produce these numbers.

- curl retry arithmetic measured against a blackholed address (table above), and
  the scaled equivalent of the new tarball settings stays bounded.
- The `make | tee` fake-green reproduced under `bash -e` with a Makefile of the
  same shape, before and after.
- SIGPIPE behaviour measured on the real module
  (`8852au.ko.xz`, 160 lines of modinfo output): `head -40` 49/50 failures under
  pipefail, `sed -n '1,40p'` 0/50.
- `shellcheck` 0.11.0 clean over the full CI lint list; `bash -n` clean.
- Patched workflow parses as YAML with all four job `name:` strings unchanged,
  so **branch protection needs no edit**.

## Checklist

- [x] `shellcheck` passes on shell changes
- [x] CHANGELOG.md updated under `## [Unreleased]` — the existing `curl` bullet
      from #49 is amended in place rather than contradicted, since it advertised
      protection that had this hole
- [x] CI is green on this branch — to be confirmed by this PR's own run
