### PR TITLE
docs: name all four kernel 7.x blockers, not just cfg80211

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,15 @@ changes in this file.
 - **`build-mainline` now records the kernel it resolved** in the job summary,
   on success as well as failure. A bare green tick did not say which version
   was actually tested, which is precisely the question a scheduled run raises.
+- **Both READMEs now say what actually blocks kernel 7.x.** They named the
+  cfg80211 callback refactor as the sole reason 7.1 does not build, and pinned
+  the expected newest-stable failure to 7.1. A probe against 7.2 found four
+  independent blockers rather than one — the cfg80211 refactor, the removal of
+  `strncpy`, the reworked pppoe structs behind `CONFIG_RTW_BR_EXT`, and a
+  dropped wiphy flag — and the newest stable has since moved on to 7.2, so the
+  version-pinned wording was going stale on its own. The build claim now reads
+  "7.1 and newer", and the CI note is phrased against the outstanding port
+  rather than one release.
 - **The DKMS dry-run no longer waits on the build matrix.** It shares no
   artefact with those jobs — `dkms-install.sh` strips `*.ko` and `*.o` out of
   the tree it copies, and `dkms build` compiles from source — so `needs: build`

--- a/README.md
+++ b/README.md
@@ -29,9 +29,12 @@ upstream changes can be re-applied later.
   patches carry the vendor source across the 6.17+ API removals; CI
   compiles it against distro kernels *and* the latest kernel.org stable
   and longterm releases, so regressions on the supported line are caught
-  early. Verified up to **Linux 7.0.12**; **kernel 7.1 does not build
-  yet** — its cfg80211 callback refactor (net_device → wireless_dev)
-  needs separate porting work.
+  early. Verified up to **Linux 7.0.12**; **kernel 7.1 and newer do not
+  build yet**. A probe against 7.2 found four independent blockers, not
+  one: the cfg80211 callback refactor (net_device → wireless_dev), the
+  removal of `strncpy`, the reworked pppoe structs behind
+  `CONFIG_RTW_BR_EXT`, and a dropped wiphy flag. Each needs separate
+  porting work.
 - **Monitor mode that stays up.** Four separate fixes for the RX-path
   crashes that plagued the vendor driver — UBSAN out-of-bounds, a
   NULL-deref, an SKB use-after-free, and a race/double-free — plus a
@@ -282,8 +285,8 @@ CI also builds against the newest kernel.org **longterm** and **stable**
 releases, resolved at run time, on every push *and* weekly on a schedule —
 so a new LTS that breaks the build surfaces the week it lands rather than
 whenever the next commit happens to arrive. Longterm is a hard gate;
-newest-stable is an informational early warning, currently expected to fail
-on kernel 7.1.
+newest-stable is an informational early warning, and it is expected to fail
+for as long as the 7.x port is outstanding (7.2 at the time of writing).
 
 ## Troubleshooting
 

--- a/README.nl.md
+++ b/README.nl.md
@@ -31,8 +31,11 @@ kunnen worden.
   API-verwijderingen; CI compileert tegen distro-kernels én de nieuwste
   kernel.org stable- en longterm-releases, zodat regressies op de
   ondersteunde lijn vroeg worden opgevangen. Geverifieerd tot **Linux
-  7.0.12**; **kernel 7.1 bouwt nog niet** — de cfg80211-callback-refactor
-  (net_device → wireless_dev) vraagt apart porteerwerk.
+  7.0.12**; **kernel 7.1 en nieuwer bouwen nog niet**. Een probe tegen 7.2
+  vond vier onafhankelijke blokkades, niet één: de
+  cfg80211-callback-refactor (net_device → wireless_dev), het verwijderen
+  van `strncpy`, de herziene pppoe-structs achter `CONFIG_RTW_BR_EXT` en
+  een geschrapte wiphy-vlag. Elk vraagt apart porteerwerk.
 - **Monitor-mode die overeind blijft.** Vier aparte fixes voor de
   RX-path-crashes die de vendor-driver teisterden — UBSAN
   out-of-bounds, een NULL-deref, een SKB use-after-free en een
@@ -295,8 +298,8 @@ CI bouwt daarnaast tegen de nieuwste **longterm**- en **stable**-releases van
 kernel.org, tijdens de run opgehaald, bij elke push *én* wekelijks volgens
 schema — zo komt een nieuwe LTS die de build breekt aan het licht in de week
 dat hij uitkomt, in plaats van pas bij de volgende commit. Longterm is een
-harde poort; nieuwste-stable is een informatieve vroege waarschuwing, die op
-kernel 7.1 momenteel faalt.
+harde poort; nieuwste-stable is een informatieve vroege waarschuwing, en die
+blijft falen zolang de 7.x-port openstaat (7.2 op het moment van schrijven).
 
 ## Probleemoplossing
 


### PR DESCRIPTION
## What this changes / Wat dit wijzigt

Both READMEs attributed the kernel 7.1 build failure entirely to the cfg80211
callback refactor (`net_device` → `wireless_dev`). The probe run against Linux
7.2 found **four independent blockers**, and the refactor is not even the one
you hit first:

1. `strncpy` was removed — 18 sites, and `_os_strncpy()` in
   `phl/pltfm_ops_linux.h` accounts for 219 of the 219 errors on its own,
   because it is included in 219 units.
2. The cfg80211 `net_device` → `wireless_dev` callback refactor (~13 errors).
3. `pppoe_hdr.tag` / `pppoe_tag.tag_data` are gone (10 errors, behind
   `CONFIG_RTW_BR_EXT`).
4. `WIPHY_FLAG_SUPPORTS_5_10_MHZ` was dropped.

Naming only the second sends anyone attempting the port at the wrong problem
first: `strncpy` fails earlier in the build, so the rest is not visible until
that is dealt with.

Second fix: the version pinning was going stale by itself. The newest kernel.org
stable is now **7.2**, so "expected to fail on kernel 7.1" describes a release
that is no longer the one CI tests — today's runs annotate 7.2. That note is now
phrased against the outstanding 7.x port rather than a single release, and the
build claim reads "7.1 and newer".

No behaviour change; documentation only. Both the English and Dutch READMEs are
updated in step.

## Type of change / Type wijziging

- [x] Documentation only / Alleen documentatie

## How was this tested / Hoe is dit getest

Documentation only — no build or hardware involved. The blocker list comes from
a `make -k` probe against Linux 7.2 that collected every error in one run.

## Checklist

- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] Docs updated where the behaviour changes — both READMEs, in step
- [x] CI is green on this branch — to be confirmed by this PR's own run